### PR TITLE
Refactor Elementor widget namespaces

### DIFF
--- a/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -1,14 +1,13 @@
 <?php
-namespace {
-    if (!defined('ABSPATH')) { exit; }
-}
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
 class OBTI_EW_Booking extends Widget_Base {
-    public function get_name(){ return 'obti-booking'; }
+    public function get_name(){ return __('obti-booking','obti'); }
     public function get_title(){ return __('OBTI Booking','obti'); }
     public function get_icon(){ return 'eicon-cart'; }
     public function get_categories(){ return ['obti']; }

--- a/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
+++ b/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
@@ -1,15 +1,14 @@
 <?php
-namespace {
-    if (!defined('ABSPATH')) { exit; }
-}
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Repeater;
 
 class OBTI_EW_FAQ extends Widget_Base {
-    public function get_name(){ return 'obti-faq'; }
+    public function get_name(){ return __('obti-faq','obti'); }
     public function get_title(){ return __('OBTI FAQ','obti'); }
     public function get_icon(){ return 'eicon-help-o'; }
     public function get_categories(){ return ['obti']; }

--- a/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
+++ b/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
@@ -1,14 +1,13 @@
 <?php
-namespace {
-    if (!defined('ABSPATH')) { exit; }
-}
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
 class OBTI_EW_Hero extends Widget_Base {
-    public function get_name(){ return 'obti-hero'; }
+    public function get_name(){ return __('obti-hero','obti'); }
     public function get_title(){ return __('OBTI Hero','obti'); }
     public function get_icon(){ return 'eicon-slider-full-screen'; }
     public function get_categories(){ return ['obti']; }

--- a/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
+++ b/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
@@ -1,15 +1,14 @@
 <?php
-namespace {
-    if (!defined('ABSPATH')) { exit; }
-}
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Repeater;
 
 class OBTI_EW_Highlights extends Widget_Base {
-    public function get_name(){ return 'obti-highlights'; }
+    public function get_name(){ return __('obti-highlights','obti'); }
     public function get_title(){ return __('OBTI Tour Highlights','obti'); }
     public function get_icon(){ return 'eicon-bullet-list'; }
     public function get_categories(){ return ['obti']; }

--- a/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -1,14 +1,13 @@
 <?php
-namespace {
-    if (!defined('ABSPATH')) { exit; }
-}
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
 class OBTI_EW_Schedule_Map extends Widget_Base {
-    public function get_name(){ return 'obti-schedule-map'; }
+    public function get_name(){ return __('obti-schedule-map','obti'); }
     public function get_title(){ return __('OBTI Schedule & Map','obti'); }
     public function get_icon(){ return 'eicon-time-line'; }
     public function get_categories(){ return ['obti']; }


### PR DESCRIPTION
## Summary
- unify widget namespaces under `OBTI_EW`
- localize widget names and titles

## Testing
- `php -l plugins/obti-elementor-widgets/widgets/class-obti-booking.php`
- `php -l plugins/obti-elementor-widgets/widgets/class-obti-faq.php`
- `php -l plugins/obti-elementor-widgets/widgets/class-obti-hero.php`
- `php -l plugins/obti-elementor-widgets/widgets/class-obti-highlights.php`
- `php -l plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php`


------
https://chatgpt.com/codex/tasks/task_e_689f72300fec83338cca43c1cc233dbe