### PR TITLE
Add Elementor dependency checks to widgets plugin

### DIFF
--- a/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -11,7 +11,22 @@ if (!defined('ABSPATH')) { exit; }
 define('OBTI_EW_DIR', plugin_dir_path(__FILE__));
 define('OBTI_EW_URL', plugin_dir_url(__FILE__));
 
+// Activation check for Elementor
+register_activation_hook(__FILE__, function(){
+    if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+        set_transient('obti_ew_missing_elementor', true);
+    }
+});
+
+add_action('admin_notices', function(){
+    if ( get_transient('obti_ew_missing_elementor') ) {
+        delete_transient('obti_ew_missing_elementor');
+        echo '<div class="notice notice-error"><p>' . esc_html__('Elementor plugin is required for OBTI Elementor Widgets.', 'obti') . '</p></div>';
+    }
+});
+
 add_action('elementor/widgets/register', function($widgets_manager){
+    if ( ! did_action( 'elementor/loaded' ) ) { return; }
     require_once OBTI_EW_DIR.'widgets/class-obti-hero.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-highlights.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-schedule-map.php';


### PR DESCRIPTION
## Summary
- Guard widget registration when Elementor isn't loaded
- Display admin notice on activation if Elementor is missing

## Testing
- `php -l plugins/obti-elementor-widgets/obti-elementor-widgets.php`


------
https://chatgpt.com/codex/tasks/task_e_689f740a64dc8333bfd3af89c5b9f771