### PR TITLE
Refactor page lookup using WP_Query helper

### DIFF
--- a/plugins/obti-booking/emails/customer-confirmed.php
+++ b/plugins/obti-booking/emails/customer-confirmed.php
@@ -8,8 +8,8 @@ $qty   = (int) get_post_meta($booking_id,'_obti_qty', true);
 $total = get_post_meta($booking_id,'_obti_total', true);
 $token = get_post_meta($booking_id,'_obti_manage_token', true);
 $address = OBTI_Settings::get('address_label','Forio');
-$account_page = get_page_by_title('My Bookings');
-$link = $account_page ? add_query_arg(['token'=>$token,'email'=>$email], get_permalink($account_page->ID)) : home_url('/');
+$account_page_id = obti_get_page_id('My Bookings');
+$link = $account_page_id ? add_query_arg(['token'=>$token,'email'=>$email], get_permalink($account_page_id)) : home_url('/');
 ?>
 <!doctype html>
 <html>

--- a/plugins/obti-booking/includes/class-obti-checkout.php
+++ b/plugins/obti-booking/includes/class-obti-checkout.php
@@ -15,10 +15,10 @@ class OBTI_Checkout {
         $total = floatval(get_post_meta($booking_id,'_obti_total', true));
         $currency = strtolower(get_post_meta($booking_id,'_obti_currency', true) ?: 'eur');
 
-        $success_page = get_page_by_title('Booking Success');
-        $cancel_page  = get_page_by_title('Booking Cancelled');
-        $success_url = $success_page ? get_permalink($success_page->ID) : home_url('/');
-        $cancel_url  = $cancel_page ? get_permalink($cancel_page->ID) : home_url('/');
+        $success_page_id = obti_get_page_id('Booking Success');
+        $cancel_page_id  = obti_get_page_id('Booking Cancelled');
+        $success_url = $success_page_id ? get_permalink($success_page_id) : home_url('/');
+        $cancel_url  = $cancel_page_id ? get_permalink($cancel_page_id) : home_url('/');
 
         $success_url = add_query_arg(['session_id'=>'{CHECKOUT_SESSION_ID}','booking_id'=>$booking_id], $success_url);
         $cancel_url  = add_query_arg(['booking_id'=>$booking_id], $cancel_url);

--- a/plugins/obti-booking/obti-booking.php
+++ b/plugins/obti-booking/obti-booking.php
@@ -21,6 +21,16 @@ require_once OBTI_PLUGIN_DIR . 'includes/class-obti-webhooks.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-cron.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-admin.php';
 
+function obti_get_page_id( $title ) {
+    $q = new WP_Query([
+        'post_type'      => 'page',
+        'title'          => $title,
+        'posts_per_page' => 1,
+        'fields'         => 'ids'
+    ]);
+    return $q->have_posts() ? intval($q->posts[0]) : 0;
+}
+
 // Activation: create pages + schedule cron + flush rewrite
 register_activation_hook(__FILE__, function(){
     if (!wp_next_scheduled('obti_cleanup_holds')) { wp_schedule_event(time()+300, 'five_minutes', 'obti_cleanup_holds'); }
@@ -40,7 +50,7 @@ function obti_maybe_create_pages(){
         'My Bookings' => '[obti_account]'
     ];
     foreach($pages as $title=>$shortcode){
-        $exists = get_page_by_title($title);
+        $exists = obti_get_page_id($title);
         if (!$exists) {
             $id = wp_insert_post([ 'post_title'=>$title, 'post_type'=>'page', 'post_status'=>'publish', 'post_content'=>$shortcode ]);
         }


### PR DESCRIPTION
## Summary
- add `obti_get_page_id` helper that uses `WP_Query` to retrieve a page ID by title
- replace `get_page_by_title` usage in checkout, emails, and page creation with new helper

## Testing
- `php -l plugins/obti-booking/obti-booking.php`
- `php -l plugins/obti-booking/includes/class-obti-checkout.php`
- `php -l plugins/obti-booking/emails/customer-confirmed.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ac5ba4c833390742f8d7653d110