### PR TITLE
Add Elementor home template and import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# OBTI WordPress Project
+
+## Elementor Home Template
+
+A prebuilt Home page layout using custom widgets is stored in [`elementor/home.json`](elementor/home.json).
+
+### Import instructions
+1. In your WordPress admin dashboard make sure the **OBTI Elementor Widgets** plugin is active so that the custom widgets are available.
+2. Navigate to **Elementor → Templates → Import Templates**.
+3. Upload the `elementor/home.json` file from this repository and click **Import**.
+4. Create or edit a page and insert the imported template to use the layout.
+
+The template includes the following widgets in order:
+`obti-hero`, `obti-highlights`, `obti-schedule-map`, `obti-faq`, and `obti-booking`.

--- a/elementor/home.json
+++ b/elementor/home.json
@@ -1,0 +1,121 @@
+{
+  "version": "0.4",
+  "title": "Home",
+  "type": "page",
+  "content": [
+    {
+      "id": "section-hero",
+      "elType": "section",
+      "settings": [],
+      "elements": [
+        {
+          "id": "column-hero",
+          "elType": "column",
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "widget-hero",
+              "elType": "widget",
+              "widgetType": "obti-hero",
+              "settings": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "section-highlights",
+      "elType": "section",
+      "settings": [],
+      "elements": [
+        {
+          "id": "column-highlights",
+          "elType": "column",
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "widget-highlights",
+              "elType": "widget",
+              "widgetType": "obti-highlights",
+              "settings": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "section-schedule-map",
+      "elType": "section",
+      "settings": [],
+      "elements": [
+        {
+          "id": "column-schedule-map",
+          "elType": "column",
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "widget-schedule-map",
+              "elType": "widget",
+              "widgetType": "obti-schedule-map",
+              "settings": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "section-faq",
+      "elType": "section",
+      "settings": [],
+      "elements": [
+        {
+          "id": "column-faq",
+          "elType": "column",
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "widget-faq",
+              "elType": "widget",
+              "widgetType": "obti-faq",
+              "settings": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "section-booking",
+      "elType": "section",
+      "settings": [],
+      "elements": [
+        {
+          "id": "column-booking",
+          "elType": "column",
+          "settings": {
+            "_column_size": 100
+          },
+          "elements": [
+            {
+              "id": "widget-booking",
+              "elType": "widget",
+              "widgetType": "obti-booking",
+              "settings": {}
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "page_settings": {},
+  "metadata": {},
+  "category": "",
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- Add exported Elementor template for home page featuring OBTI widgets.
- Document import steps for the template in README.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689f858b97f88333831a928f8bac3ea6