### PR TITLE
Add Totaliweb transfers management

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-admin.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-admin.php
@@ -19,6 +19,7 @@ class OBTI_Admin {
             'service_fee' => get_post_meta($post->ID,'_obti_service_fee', true),
             'agency_fee' => get_post_meta($post->ID,'_obti_agency_fee', true),
             'total'=> get_post_meta($post->ID,'_obti_total', true),
+            'fee_transferred' => get_post_meta($post->ID,'_obti_fee_transferred', true),
             'email'=> get_post_meta($post->ID,'_obti_email', true),
             'name' => get_post_meta($post->ID,'_obti_name', true),
             'session' => get_post_meta($post->ID,'_obti_stripe_session_id', true),

--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -143,6 +143,7 @@ class OBTI_REST {
         update_post_meta($post_id, '_obti_hold_expires', $hold_expires);
         $token = wp_generate_password(32,false,false);
         update_post_meta($post_id, '_obti_manage_token', $token);
+        update_post_meta($post_id, '_obti_fee_transferred', 'no');
 
         // Create Stripe Checkout Session
         $checkout = OBTI_Checkout::create_checkout_session($post_id);
@@ -162,6 +163,7 @@ class OBTI_REST {
         $email = sanitize_email($params['email'] ?? '');
         if (!$booking_id || !$token || !$email) return new WP_REST_Response(['error'=>'bad_request'], 400);
         if (get_post_meta($booking_id, '_obti_manage_token', true) !== $token) return new WP_REST_Response(['error'=>'unauthorized'], 403);
+        update_post_meta($post_id, '_obti_fee_transferred', 'no');
         if (get_post_meta($booking_id, '_obti_email', true) !== $email) return new WP_REST_Response(['error'=>'unauthorized'], 403);
         if (!obti_can_cancel($booking_id)) return new WP_REST_Response(['error'=>'cannot_cancel_yet','message'=>__('You can cancel up to 72h before start.','obti')], 400);
 

--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -51,6 +51,7 @@ class OBTI_Admin_Settings_Page {
         add_menu_page('OBTI Booking', 'OBTI Booking', 'manage_options', 'obti-booking', [__CLASS__, 'render'], 'dashicons-tickets', 26);
         add_submenu_page('obti-booking', __('Settings','obti'), __('Settings','obti'), 'manage_options', 'obti-booking', [__CLASS__, 'render']);
         add_submenu_page('obti-booking', __('Capacity Overrides','obti'), __('Capacity Overrides','obti'), 'manage_options', 'obti-capacity', [__CLASS__, 'render_overrides']);
+        add_submenu_page('obti-booking', __('Transfers Totaliweb','obti'), __('Transfers Totaliweb','obti'), 'manage_options', 'obti-transfers', ['OBTI_Transfers','render']);
     }
     public static function register(){
         register_setting('obti_settings_group', 'obti_settings');

--- a/wp-content/plugins/obti-booking/includes/class-obti-transfers.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-transfers.php
@@ -1,0 +1,89 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+if (!class_exists('WP_List_Table')) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class OBTI_Transfers_Table extends WP_List_Table {
+    public function get_columns(){
+        return [
+            'cliente' => __('Cliente','obti'),
+            'data' => __('Data/Ora','obti'),
+            'totale' => __('Totale','obti'),
+            'fee' => __('Fee (2.5%)','obti'),
+            'transferred' => __('Stato trasferimento','obti'),
+        ];
+    }
+
+    public function prepare_items(){
+        $bookings = get_posts([
+            'post_type' => 'obti_booking',
+            'post_status' => ['obti-confirmed','obti-completed'],
+            'posts_per_page' => -1,
+        ]);
+        $items = [];
+        foreach($bookings as $p){
+            $total = (float) get_post_meta($p->ID,'_obti_total', true);
+            $items[] = [
+                'ID' => $p->ID,
+                'cliente' => get_post_meta($p->ID,'_obti_name', true).' <'.get_post_meta($p->ID,'_obti_email', true).'>',
+                'data' => get_post_meta($p->ID,'_obti_date', true).' '.get_post_meta($p->ID,'_obti_time', true),
+                'totale' => number_format($total, 2),
+                'fee' => number_format($total * 0.025, 2),
+                'transferred' => get_post_meta($p->ID,'_obti_fee_transferred', true) === 'yes' ? 'yes' : 'no',
+            ];
+        }
+        $this->items = $items;
+    }
+
+    public function column_default($item, $column_name){
+        return esc_html($item[$column_name]);
+    }
+
+    public function column_totale($item){
+        return '€'.esc_html($item['totale']);
+    }
+
+    public function column_fee($item){
+        return '€'.esc_html($item['fee']);
+    }
+
+    public function column_transferred($item){
+        if ($item['transferred'] === 'yes'){
+            return esc_html__('Yes','obti');
+        }
+        $nonce = wp_create_nonce('obti_mark_transferred_'.$item['ID']);
+        $url = admin_url('admin-post.php?action=obti_mark_transferred&booking='.$item['ID'].'&_wpnonce='.$nonce);
+        return esc_html__('No','obti').' <a class="button" href="'.esc_url($url).'">'.esc_html__('Mark transferred','obti').'</a>';
+    }
+}
+
+class OBTI_Transfers {
+    public static function init(){
+        add_action('admin_post_obti_mark_transferred',[__CLASS__,'handle_mark_transferred']);
+    }
+
+    public static function render(){
+        $table = new OBTI_Transfers_Table();
+        $table->prepare_items();
+        echo '<div class="wrap"><h1>Transfers Totaliweb</h1>';
+        $table->display();
+        echo '</div>';
+    }
+
+    public static function set_transferred($booking_id){
+        update_post_meta($booking_id, '_obti_fee_transferred', 'yes');
+    }
+
+    public static function handle_mark_transferred(){
+        if (!current_user_can('manage_options')) { wp_die(__('Unauthorized','obti')); }
+        $booking_id = isset($_GET['booking']) ? intval($_GET['booking']) : 0;
+        if (!$booking_id || !isset($_GET['_wpnonce']) || !wp_verify_nonce($_GET['_wpnonce'], 'obti_mark_transferred_'.$booking_id)){
+            wp_die(__('Invalid request','obti'));
+        }
+        self::set_transferred($booking_id);
+        wp_redirect(add_query_arg(['page'=>'obti-transfers','updated'=>1], admin_url('admin.php')));
+        exit;
+    }
+}
+OBTI_Transfers::init();

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -20,6 +20,7 @@ require_once OBTI_PLUGIN_DIR . 'includes/class-obti-checkout.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-webhooks.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-cron.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-admin.php';
+require_once OBTI_PLUGIN_DIR . 'includes/class-obti-transfers.php';
 
 function obti_get_page_id( $title ) {
     $q = new WP_Query([


### PR DESCRIPTION
## Summary
- add “Transfers Totaliweb” admin submenu
- list bookings and mark fees as transferred
- track `_obti_fee_transferred` meta on bookings

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-transfers.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -l wp-content/plugins/obti-booking/obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-admin.php`
- `php /tmp/test_transfers.php`


------
https://chatgpt.com/codex/tasks/task_e_689f8f8d975c83338974931b7aea29fb