### PR TITLE
Add authenticated booking transfer endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,30 @@ A prebuilt Home page layout using custom widgets is stored in [`wp-content/eleme
 4. Create or edit a page and insert the imported template to use the layout.
 
 The template includes the following widgets in order: `obti-hero`, `obti-highlights`, `obti-schedule-map`, `obti-faq`, and `obti-booking`.
+
+## Booking REST API
+
+The `obti-booking` plugin exposes authenticated endpoints under `/wp-json/obti/v1`.
+
+### Authentication
+
+Requests must include either:
+
+- `Authorization: Bearer <API_KEY>` header where the key is configured in the plugin settings.
+- A logged-in WordPress user via OAuth or another supported auth method.
+
+### List bookings
+
+```
+GET /wp-json/obti/v1/bookings?date=2024-01-01&status=obti-confirmed
+```
+
+Returns an array of bookings with fields `id`, `customer`, `date`, `time`, `qty`, `total`, `agency_fee` and `transfer_status`.
+
+### Mark transfer
+
+```
+PATCH /wp-json/obti/v1/bookings/{id}/transfer
+```
+
+Marks the Totaliweb agency fee as transferred for the given booking. Optionally send `status=no` to reset.

--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -14,6 +14,7 @@ class OBTI_Settings {
             'service_fee_percent' => 0, // % passed to customer as "service fee"
             'agency_fee_percent' => 2.5, // Totaliweb percent
             'address_label' => 'Via Filippo di Lustro 19, 80075 Forio (NA)',
+            'api_key' => '',
             'stripe_mode' => 'test',
             'stripe_secret_key' => '',
             'stripe_publishable_key' => '',
@@ -85,6 +86,8 @@ class OBTI_Admin_Settings_Page {
                 <td><input type="number" step="0.01" name="obti_settings[agency_fee_percent]" value="<?php echo esc_attr($o['agency_fee_percent']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Start/Return point label','obti'); ?></th>
                 <td><input type="text" size="60" name="obti_settings[address_label]" value="<?php echo esc_attr($o['address_label']); ?>"></td></tr>
+              <tr><th><?php esc_html_e('API Key for REST','obti'); ?></th>
+                <td><input type="text" size="60" name="obti_settings[api_key]" value="<?php echo esc_attr($o['api_key']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Stripe mode','obti'); ?></th>
                 <td>
                   <select name="obti_settings[stripe_mode]">


### PR DESCRIPTION
## Summary
- add API key-protected endpoints for listing bookings and marking transfers
- support configuring REST API key in booking settings
- document booking API authentication and usage

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689f926c83408333a0e9a859aca974bb