### PR TITLE
Refactor Elementor widget namespaces

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -32,11 +32,11 @@ add_action('elementor/widgets/register', function($widgets_manager){
     require_once OBTI_EW_DIR.'widgets/class-obti-schedule-map.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-faq.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-booking.php';
-    $widgets_manager->register( new \OBTI_EW_Hero() );
-    $widgets_manager->register( new \OBTI_EW_Highlights() );
-    $widgets_manager->register( new \OBTI_EW_Schedule_Map() );
-    $widgets_manager->register( new \OBTI_EW_FAQ() );
-    $widgets_manager->register( new \OBTI_EW_Booking() );
+    $widgets_manager->register( new \OBTI_EW\Hero() );
+    $widgets_manager->register( new \OBTI_EW\Highlights() );
+    $widgets_manager->register( new \OBTI_EW\Schedule_Map() );
+    $widgets_manager->register( new \OBTI_EW\FAQ() );
+    $widgets_manager->register( new \OBTI_EW\Booking() );
 });
 
 // Category

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
-class OBTI_EW_Booking extends Widget_Base {
+class Booking extends Widget_Base {
     public function get_name(){ return __('obti-booking','obti'); }
     public function get_title(){ return __('OBTI Booking','obti'); }
     public function get_icon(){ return 'eicon-cart'; }

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
@@ -7,7 +7,7 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Repeater;
 
-class OBTI_EW_FAQ extends Widget_Base {
+class FAQ extends Widget_Base {
     public function get_name(){ return __('obti-faq','obti'); }
     public function get_title(){ return __('OBTI FAQ','obti'); }
     public function get_icon(){ return 'eicon-help-o'; }

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
-class OBTI_EW_Hero extends Widget_Base {
+class Hero extends Widget_Base {
     public function get_name(){ return __('obti-hero','obti'); }
     public function get_title(){ return __('OBTI Hero','obti'); }
     public function get_icon(){ return 'eicon-slider-full-screen'; }

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
@@ -7,7 +7,7 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Repeater;
 
-class OBTI_EW_Highlights extends Widget_Base {
+class Highlights extends Widget_Base {
     public function get_name(){ return __('obti-highlights','obti'); }
     public function get_title(){ return __('OBTI Tour Highlights','obti'); }
     public function get_icon(){ return 'eicon-bullet-list'; }

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
-class OBTI_EW_Schedule_Map extends Widget_Base {
+class Schedule_Map extends Widget_Base {
     public function get_name(){ return __('obti-schedule-map','obti'); }
     public function get_title(){ return __('OBTI Schedule & Map','obti'); }
     public function get_icon(){ return 'eicon-time-line'; }


### PR DESCRIPTION
## Summary
- Drop `OBTI_EW_` prefixes from widget class names and keep them within the `OBTI_EW` namespace
- Instantiate widgets using namespaced classes in plugin bootstrap

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php`


------
https://chatgpt.com/codex/tasks/task_e_689f9afe0b788333a8ccb5b4e9b28617