### PR TITLE
Add language switch, booking button, and social links

### DIFF
--- a/wp-content/themes/obti/footer.php
+++ b/wp-content/themes/obti/footer.php
@@ -3,7 +3,27 @@
 <footer class="bg-gray-800 text-white py-12 mt-16">
   <div class="container mx-auto px-6 text-center">
     <p class="text-xl font-bold">OpenBusTour<span class="theme-primary">Ischia</span>.com</p>
-    <p class="mt-4">For info: <a class="theme-primary hover:underline" href="mailto:info@openbustourischia.com">info@openbustourischia.com</a></p>
+    <?php
+      $email = get_theme_mod('obti_email');
+      if ($email) : ?>
+        <p class="mt-4">For info: <a class="theme-primary hover:underline" href="mailto:<?php echo esc_attr($email); ?>"><?php echo esc_html($email); ?></a></p>
+    <?php endif; ?>
+    <?php
+      $socials = [
+        'facebook'  => get_theme_mod('obti_facebook_url'),
+        'instagram' => get_theme_mod('obti_instagram_url'),
+        'tiktok'    => get_theme_mod('obti_tiktok_url'),
+      ];
+      $socials = array_filter($socials);
+      if ($socials) : ?>
+        <div class="flex justify-center space-x-6 mt-6">
+          <?php foreach ($socials as $icon => $url) : ?>
+            <a href="<?php echo esc_url($url); ?>" target="_blank" rel="noopener" class="hover:text-theme-primary">
+              <i data-lucide="<?php echo esc_attr($icon); ?>"></i>
+            </a>
+          <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
     <p class="mt-8 text-sm text-gray-500">&copy; <?php echo date('Y'); ?> Open Bus Tour Ischia. All Rights Reserved.</p>
   </div>
 </footer>

--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -29,3 +29,38 @@ add_action('wp_footer', function(){
 add_action('after_setup_theme', function(){
     register_nav_menus([ 'primary' => __('Primary Menu','obti') ]);
 });
+
+// Theme settings for contact info and socials
+add_action('customize_register', function($wp_customize){
+    $wp_customize->add_section('obti_theme_settings', [
+        'title'    => __('Theme Settings', 'obti'),
+        'priority' => 30,
+    ]);
+
+    // Email address
+    $wp_customize->add_setting('obti_email', [
+        'sanitize_callback' => 'sanitize_email',
+    ]);
+    $wp_customize->add_control('obti_email', [
+        'label'   => __('Contact Email', 'obti'),
+        'section' => 'obti_theme_settings',
+        'type'    => 'email',
+    ]);
+
+    $socials = [
+        'facebook'  => __('Facebook URL', 'obti'),
+        'instagram' => __('Instagram URL', 'obti'),
+        'tiktok'    => __('TikTok URL', 'obti'),
+    ];
+
+    foreach ($socials as $id => $label) {
+        $wp_customize->add_setting("obti_{$id}_url", [
+            'sanitize_callback' => 'esc_url_raw',
+        ]);
+        $wp_customize->add_control("obti_{$id}_url", [
+            'label'   => $label,
+            'section' => 'obti_theme_settings',
+            'type'    => 'url',
+        ]);
+    }
+});

--- a/wp-content/themes/obti/header.php
+++ b/wp-content/themes/obti/header.php
@@ -7,7 +7,7 @@
 <?php wp_head(); ?>
 </head>
 <body <?php body_class('bg-gray-50 text-gray-800'); ?>>
-<header id="site-header" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300">
+<header id="site-header" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300 bg-white">
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <a class="text-2xl font-bold text-gray-800" href="<?php echo esc_url(home_url('/')); ?>">
       OpenBusTour<span class="theme-primary">Ischia</span>.com
@@ -16,21 +16,37 @@
       <?php
         wp_nav_menu([
           'theme_location' => 'primary',
-          'container' => false,
-          'items_wrap' => '%3$s',
-          'fallback_cb' => false
+          'container'    => false,
+          'items_wrap'   => '%3$s',
+          'fallback_cb'  => false
         ]);
       ?>
     </nav>
+    <div class="hidden md:flex items-center space-x-6">
+      <div class="flex items-center space-x-1 text-sm font-semibold">
+        <a href="#" class="hover:text-theme-primary">EN</a>
+        <span>|</span>
+        <a href="#" class="hover:text-theme-primary">IT</a>
+      </div>
+      <a href="#" class="bg-theme-primary text-white px-4 py-2 rounded">Book Now</a>
+    </div>
     <button id="mobile-menu-button" class="md:hidden"><i data-lucide="menu"></i></button>
   </div>
   <div id="mobile-menu" class="hidden md:hidden bg-white px-6 pb-4">
+    <div class="py-4 flex items-center justify-between border-b">
+      <div class="flex items-center space-x-1 text-sm font-semibold">
+        <a href="#" class="hover:text-theme-primary">EN</a>
+        <span>|</span>
+        <a href="#" class="hover:text-theme-primary">IT</a>
+      </div>
+      <a href="#" class="bg-theme-primary text-white px-4 py-2 rounded">Book Now</a>
+    </div>
     <?php
       wp_nav_menu([
         'theme_location' => 'primary',
-        'container' => false,
-        'items_wrap' => '<ul class="space-y-2">%3$s</ul>',
-        'fallback_cb' => false
+        'container'      => false,
+        'items_wrap'     => '<ul class="space-y-2 py-4">%3$s</ul>',
+        'fallback_cb'    => false
       ]);
     ?>
   </div>


### PR DESCRIPTION
## Summary
- Add desktop and mobile language switch and Book Now button in header
- Output theme-mod email and social icons in footer
- Register Customizer settings for contact email and social URLs

## Testing
- `php -l wp-content/themes/obti/header.php`
- `php -l wp-content/themes/obti/footer.php`
- `php -l wp-content/themes/obti/functions.php`
- `npm test` (fails: Missing script)
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_689fb0cfbb5c8333855be8bfe7f4875e