### PR TITLE
Add Customizer options for socials, Mapbox, and Chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ npm install
 npm run build:css
 ```
 
+## Theme Customizer Settings
+
+The theme adds a **Theme Settings** section under *Appearance → Customize* with the following options:
+
+- **Facebook URL** (`social_facebook`)
+- **Instagram URL** (`social_instagram`)
+- **Twitter URL** (`social_twitter`)
+- **Mapbox Token** (`mapbox_token`) – used by the Schedule & Map widget
+- **Chatbot API Key** (`chatbot_api_key`) – used by the Chatbot widget
+
 ## Elementor Home Template
 
 A prebuilt Home page layout using custom widgets is stored in [`wp-content/elementor/home.json`](wp-content/elementor/home.json).

--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -32,11 +32,13 @@ add_action('elementor/widgets/register', function($widgets_manager){
     require_once OBTI_EW_DIR.'widgets/class-obti-schedule-map.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-faq.php';
     require_once OBTI_EW_DIR.'widgets/class-obti-booking.php';
+    require_once OBTI_EW_DIR.'widgets/class-obti-chatbot.php';
     $widgets_manager->register( new \OBTI_EW\Hero() );
     $widgets_manager->register( new \OBTI_EW\Highlights() );
     $widgets_manager->register( new \OBTI_EW\Schedule_Map() );
     $widgets_manager->register( new \OBTI_EW\FAQ() );
     $widgets_manager->register( new \OBTI_EW\Booking() );
+    $widgets_manager->register( new \OBTI_EW\Chatbot() );
 });
 
 // Category

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
@@ -1,0 +1,20 @@
+<?php
+namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+use Elementor\Widget_Base;
+
+class Chatbot extends Widget_Base {
+    public function get_name(){ return 'obti-chatbot'; }
+    public function get_title(){ return __('OBTI Chatbot','obti'); }
+    public function get_icon(){ return 'eicon-chat'; }
+    public function get_categories(){ return ['obti']; }
+
+    protected function render(){
+        $api_key = get_theme_mod('chatbot_api_key');
+        ?>
+        <div id="obti-chatbot" data-api-key="<?php echo esc_attr($api_key); ?>"></div>
+        <?php
+    }
+}

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -25,6 +25,7 @@ class Schedule_Map extends Widget_Base {
 
     protected function render(){
         $s = $this->get_settings_for_display();
+        $token = get_theme_mod('mapbox_token');
         ?>
         <section class="py-20">
           <div class="container mx-auto px-6">
@@ -44,7 +45,7 @@ class Schedule_Map extends Widget_Base {
                 <p class="text-gray-600"><?php echo esc_html($s['afternoon_desc']); ?></p>
               </div>
               <div class="md:col-span-2 lg:col-span-1 bg-white p-6 rounded-2xl shadow-lg flex flex-col items-center justify-center">
-                <div class="map-container-3d w-full max-w-[280px] mx-auto">
+                <div class="map-container-3d w-full max-w-[280px] mx-auto"<?php if ($token) echo ' data-mapbox-token="' . esc_attr($token) . '"'; ?>>
                   <svg id="ischia-map" viewBox="0 0 250 220" xmlns="http://www.w3.org/2000/svg">
                     <path d="M191.1,52.3C171.3,21.1,133,12.3,96.3,27.5C59.5,42.7,37,80.1,42.5,119.5c5.5,39.4,36.4,71.2,75.8,76.5c39.4,5.3,77.5-16.1,92.5-52.9c15-36.8,4.3-79.3-25.7-99.3" fill="none" stroke="white" stroke-width="3" stroke-dasharray="8 5" opacity="0.7"/>
                     <path id="ischia-island-shape" d="M200.3,72.4c-13.3-21.2-35.9-34.9-61.1-37.3c-25.2-2.4-50.5,6.5-68.9,24.1c-18.4,17.6-28.4,42.6-27.4,68.6c1,26,13.1,50.1,33.1,65.8c20,15.7,46.5,21.4,72.2,15.2c25.7-6.2,47.4-23.4,60.3-46.2c12.9-22.8,16.1-50-0.6-72.2C205.8,87.1,203.4,79.2,200.3,72.4z" fill="#16a34a" stroke="#15803d" stroke-width="1.5"/>

--- a/wp-content/themes/obti/footer.php
+++ b/wp-content/themes/obti/footer.php
@@ -10,9 +10,9 @@
     <?php endif; ?>
     <?php
       $socials = [
-        'facebook'  => get_theme_mod('obti_facebook_url'),
-        'instagram' => get_theme_mod('obti_instagram_url'),
-        'tiktok'    => get_theme_mod('obti_tiktok_url'),
+        'facebook'  => get_theme_mod('social_facebook'),
+        'instagram' => get_theme_mod('social_instagram'),
+        'twitter'   => get_theme_mod('social_twitter'),
       ];
       $socials = array_filter($socials);
       if ($socials) : ?>

--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -48,19 +48,37 @@ add_action('customize_register', function($wp_customize){
     ]);
 
     $socials = [
-        'facebook'  => __('Facebook URL', 'obti'),
-        'instagram' => __('Instagram URL', 'obti'),
-        'tiktok'    => __('TikTok URL', 'obti'),
+        'social_facebook'  => __('Facebook URL', 'obti'),
+        'social_instagram' => __('Instagram URL', 'obti'),
+        'social_twitter'   => __('Twitter URL', 'obti'),
     ];
 
     foreach ($socials as $id => $label) {
-        $wp_customize->add_setting("obti_{$id}_url", [
+        $wp_customize->add_setting($id, [
             'sanitize_callback' => 'esc_url_raw',
         ]);
-        $wp_customize->add_control("obti_{$id}_url", [
+        $wp_customize->add_control($id, [
             'label'   => $label,
             'section' => 'obti_theme_settings',
             'type'    => 'url',
         ]);
     }
+
+    $wp_customize->add_setting('mapbox_token', [
+        'sanitize_callback' => 'sanitize_text_field',
+    ]);
+    $wp_customize->add_control('mapbox_token', [
+        'label'   => __('Mapbox Token', 'obti'),
+        'section' => 'obti_theme_settings',
+        'type'    => 'text',
+    ]);
+
+    $wp_customize->add_setting('chatbot_api_key', [
+        'sanitize_callback' => 'sanitize_text_field',
+    ]);
+    $wp_customize->add_control('chatbot_api_key', [
+        'label'   => __('Chatbot API Key', 'obti'),
+        'section' => 'obti_theme_settings',
+        'type'    => 'text',
+    ]);
 });

--- a/wp-content/themes/obti/header.php
+++ b/wp-content/themes/obti/header.php
@@ -23,6 +23,23 @@
       ?>
     </nav>
     <div class="hidden md:flex items-center space-x-6">
+      <?php
+        $socials = [
+          'facebook'  => get_theme_mod('social_facebook'),
+          'instagram' => get_theme_mod('social_instagram'),
+          'twitter'   => get_theme_mod('social_twitter'),
+        ];
+        $socials = array_filter($socials);
+        if ($socials) :
+      ?>
+      <div class="flex items-center space-x-4">
+        <?php foreach ($socials as $icon => $url) : ?>
+          <a href="<?php echo esc_url($url); ?>" target="_blank" rel="noopener" class="hover:text-theme-primary">
+            <i data-lucide="<?php echo esc_attr($icon); ?>"></i>
+          </a>
+        <?php endforeach; ?>
+      </div>
+      <?php endif; ?>
       <div class="flex items-center space-x-1 text-sm font-semibold">
         <a href="#" class="hover:text-theme-primary">EN</a>
         <span>|</span>
@@ -41,6 +58,22 @@
       </div>
       <a href="#" class="bg-theme-primary text-white px-4 py-2 rounded">Book Now</a>
     </div>
+    <?php
+      $mobile_socials = [
+        'facebook'  => get_theme_mod('social_facebook'),
+        'instagram' => get_theme_mod('social_instagram'),
+        'twitter'   => get_theme_mod('social_twitter'),
+      ];
+      $mobile_socials = array_filter($mobile_socials);
+      if ($mobile_socials) : ?>
+      <div class="flex justify-center space-x-6 py-4 border-b">
+        <?php foreach ($mobile_socials as $icon => $url) : ?>
+          <a href="<?php echo esc_url($url); ?>" target="_blank" rel="noopener" class="hover:text-theme-primary">
+            <i data-lucide="<?php echo esc_attr($icon); ?>"></i>
+          </a>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
     <?php
       wp_nav_menu([
         'theme_location' => 'primary',


### PR DESCRIPTION
## Summary
- add Theme Settings section for social links, Mapbox token, and Chatbot API key
- display social links in header and footer using theme mods
- expose Mapbox token in Schedule & Map widget and add new Chatbot widget

## Testing
- `php -l wp-content/themes/obti/functions.php`
- `php -l wp-content/themes/obti/header.php`
- `php -l wp-content/themes/obti/footer.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php`
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb37ee51c8333bd79bc3f123dd876