### PR TITLE
Add Mapbox route map with animated marker

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -52,4 +52,6 @@ add_action('elementor/elements/categories_registered', function($elements_manage
 // Assets for booking widget
 add_action('wp_enqueue_scripts', function(){
     wp_register_script('obti-booking-widget', OBTI_EW_URL.'assets/js/booking-widget.js', [], '1.0.0', true);
+    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], '2.15.0', true);
+    wp_enqueue_script('turf', 'https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js', [], '6.5.0', true);
 });


### PR DESCRIPTION
## Summary
- replace static SVG with Mapbox-powered map and animated marker
- enqueue Mapbox GL JS and Turf.js for map rendering

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php`
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb74072888333b137bab59e587a3a