### PR TITLE
Integrate Flatpickr in booking widget

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
@@ -7,7 +7,7 @@
     var form = qs('#obti-booking-form');
     if (!form) return;
     var api = form.getAttribute('data-api');
-    var date = qs('input[name="date"]', form);
+    var date = qs("#date-picker", form);
     var time = qs('select[name="time"]', form);
     var qty  = qs('input[name="qty"]', form);
     var name = qs('input[name="name"]', form);
@@ -17,9 +17,7 @@
     var availLabel = qs('#obti-availability-label');
     var payBtn = qs('#obti-pay-btn');
 
-    // min date = today
-    var today = new Date().toISOString().split('T')[0];
-    date.setAttribute('min', today);
+    flatpickr('#date-picker', { minDate: 'today', dateFormat: 'Y-m-d' });
 
     function updateAvailability(){
       if (!date.value) return;

--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -51,7 +51,9 @@ add_action('elementor/elements/categories_registered', function($elements_manage
 
 // Assets for booking widget
 add_action('wp_enqueue_scripts', function(){
-    wp_register_script('obti-booking-widget', OBTI_EW_URL.'assets/js/booking-widget.js', [], '1.0.0', true);
+    wp_register_script('flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr', [], '4.6.13', true);
+    wp_register_style('flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css', [], '4.6.13');
+    wp_register_script('obti-booking-widget', OBTI_EW_URL.'assets/js/booking-widget.js', ['flatpickr'], '1.0.0', true);
     wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], '2.15.0', true);
     wp_enqueue_script('turf', 'https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js', [], '6.5.0', true);
 });

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -20,6 +20,7 @@ class Booking extends Widget_Base {
     }
 
     protected function render(){
+        wp_enqueue_style('flatpickr');
         wp_enqueue_script('obti-booking-widget');
         $ajax = esc_url( rest_url('obti/v1') );
         ?>
@@ -35,7 +36,7 @@ class Booking extends Widget_Base {
                   <div class="space-y-6">
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Date','obti'); ?></label>
-                      <input type="date" name="date" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                      <input id="date-picker" name="date" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Tour Time','obti'); ?></label>
@@ -71,7 +72,8 @@ class Booking extends Widget_Base {
                   <hr class="border-green-400 my-4">
                   <div class="flex justify-between text-2xl font-bold"><span><?php esc_html_e('Total:','obti'); ?></span><span id="obti-sum-total">€<?php echo esc_html( number_format( (float)\OBTI_Settings::get('price',20), 2 ) ); ?></span></div>
                 </div>
-                <button id="obti-pay-btn" form="obti-booking-form" class="mt-8 w-full bg-white text-theme-primary font-bold py-3 px-6 rounded-full text-lg hover:bg-gray-100 transition-all duration-300 flex items-center justify-center space-x-2">
+                <button type="submit" id="obti-pay-btn" form="obti-booking-form" class="mt-8 w-full bg-yellow-400 text-gray-900 font-bold py-3 px-6 rounded-full text-lg hover:bg-yellow-500 transition-all duration-300 flex items-center justify-center space-x-2">
+                  <i data-lucide="credit-card"></i>
                   <span><?php esc_html_e('Pay with Stripe','obti'); ?></span>
                 </button>
                 <p class="text-xs text-center mt-4 text-green-200"><?php esc_html_e('Secure payment guaranteed','obti'); ?></p>


### PR DESCRIPTION
## Summary
- Replace native date input with Flatpickr-powered picker and update payment button styling
- Enqueue Flatpickr assets and initialize picker in booking widget script

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php` *(fails: No such file or directory)*
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php` *(fails: No such file or directory)*
- `node --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fb8fe69988333aaaea525e3733a8b