### PR TITLE
Update Elementor home template with 1280px container

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A prebuilt Home page layout using custom widgets is stored in [`wp-content/eleme
 1. Ensure the **OBTI Elementor Widgets** plugin is active so that the custom widgets are available.
 2. Navigate to **Elementor → Templates → Import Templates** in the WordPress admin.
 3. Upload the `wp-content/elementor/home.json` file from this repository and click **Import**.
-4. Create or edit a page and insert the imported template to use the layout.
+4. Create or edit a page and insert the imported template to use the layout. The template sets the container width to **1280px**.
 
 The template includes the following widgets in order: `obti-hero`, `obti-highlights`, `obti-schedule-map`, `obti-faq`, and `obti-booking`.
 

--- a/wp-content/elementor/home.json
+++ b/wp-content/elementor/home.json
@@ -114,7 +114,9 @@
       ]
     }
   ],
-  "page_settings": {},
+  "page_settings": {
+    "container_width": 1280
+  },
   "metadata": {},
   "category": "",
   "tags": []


### PR DESCRIPTION
## Summary
- export refreshed Elementor `home.json` using 1280px container width
- document how to import the template and note the 1280px layout

## Testing
- `python -m json.tool wp-content/elementor/home.json`
- `markdownlint README.md` *(fails: line-length and formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf416780833383ec04f7f23a37ae