### PR TITLE
Add chatbot widget and enqueue external libraries

### DIFF
--- a/wp-content/themes/obti/assets/js/chatbot.js
+++ b/wp-content/themes/obti/assets/js/chatbot.js
@@ -1,0 +1,63 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    var wrap = document.getElementById('obti-chatbot');
+    if(!wrap) return;
+    var cfg = window.obtiConfig || {};
+    var apiKey = wrap.getAttribute('data-api-key') || cfg.chatbot_api_key || '';
+
+    var toggleBtn = document.createElement('button');
+    toggleBtn.className = 'obti-chatbot-toggle';
+    toggleBtn.innerHTML = '<i data-lucide="message-circle"></i>';
+    document.body.appendChild(toggleBtn);
+
+    var box = document.createElement('div');
+    box.className = 'obti-chatbot-box hidden';
+    box.innerHTML = '\
+<div class="obti-chat-header">\
+  <span>Chatbot</span>\
+  <button type="button" class="obti-chat-close">&times;</button>\
+</div>\
+<div class="obti-chat-messages"></div>\
+<form class="obti-chat-form">\
+  <input type="text" placeholder="Chiedi..." class="obti-chat-input" />\
+  <button type="submit">Invia</button>\
+</form>';
+    document.body.appendChild(box);
+
+    function toggle(){
+      box.classList.toggle('hidden');
+      if(window.lucide){ lucide.createIcons(); }
+    }
+
+    toggleBtn.addEventListener('click', toggle);
+    box.querySelector('.obti-chat-close').addEventListener('click', toggle);
+
+    var messages = box.querySelector('.obti-chat-messages');
+    var form = box.querySelector('.obti-chat-form');
+
+    function addMessage(role, text){
+      var div = document.createElement('div');
+      div.className = 'obti-chat-' + role;
+      div.textContent = text;
+      messages.appendChild(div);
+      messages.scrollTop = messages.scrollHeight;
+    }
+
+    form.addEventListener('submit', function(e){
+      e.preventDefault();
+      var input = box.querySelector('.obti-chat-input');
+      var text = input.value.trim();
+      if(!text) return;
+      addMessage('user', text);
+      input.value = '';
+      fetch('https://example.com/chat', {
+        method: 'POST',
+        headers: { 'Content-Type':'application/json', 'Authorization': 'Bearer ' + apiKey },
+        body: JSON.stringify({ message: text })
+      })
+      .then(function(r){ return r.json(); })
+      .then(function(d){ addMessage('bot', d.answer || 'Nessuna risposta'); })
+      .catch(function(){ addMessage('bot', 'Errore di rete'); });
+    });
+  });
+})();

--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -10,10 +10,25 @@ add_action('after_setup_theme', function(){
 
 // Enqueue assets (compiled CSS and Lucide icons)
 add_action('wp_enqueue_scripts', function(){
-    // Lucide icons
-    wp_enqueue_script('obti-lucide', 'https://unpkg.com/lucide@latest', [], null, true);
     // Compiled Tailwind CSS
     wp_enqueue_style('obti-css', get_template_directory_uri() . '/assets/css/obti.css', [], '1.0.0');
+
+    // Lucide icons
+    wp_enqueue_script('obti-lucide', 'https://unpkg.com/lucide@latest', [], null, true);
+
+    // Third-party libraries
+    wp_enqueue_script('flatpickr', 'https://cdn.jsdelivr.net/npm/flatpickr', [], null, true);
+    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], null, true);
+    wp_enqueue_script('turf', 'https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js', [], null, true);
+
+    // Chatbot widget
+    wp_enqueue_script('obti-chatbot', get_template_directory_uri() . '/assets/js/chatbot.js', [], '1.0.0', true);
+
+    // Localize tokens
+    wp_localize_script('obti-chatbot', 'obtiConfig', [
+        'mapbox_token'    => get_theme_mod('mapbox_token'),
+        'chatbot_api_key' => get_theme_mod('chatbot_api_key'),
+    ]);
 });
 
 // Add a small script to init lucide icons after DOM ready


### PR DESCRIPTION
## Summary
- Load Flatpickr, Mapbox GL, Turf, Lucide, and custom chatbot script
- Pass Mapbox token and Chatbot API key to frontend via `wp_localize_script`
- Implement basic Chatbot widget logic in `assets/js/chatbot.js`

## Testing
- `php -l wp-content/themes/obti/functions.php`
- `node --check wp-content/themes/obti/assets/js/chatbot.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fc09657948333a2f526549e89b46c