### PR TITLE
Add Totaliweb footer to booking emails

### DIFF
--- a/wp-content/plugins/obti-booking/emails/admin-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/admin-confirmed.php
@@ -16,5 +16,7 @@ $total = get_post_meta($booking_id,'_obti_total', true);
     <li>Tickets: <?php echo esc_html($qty); ?></li>
     <li>Total: €<?php echo esc_html($total); ?></li>
   </ul>
-  <p><em>Powered by <a href="https://www.totaliweb.com">Totaliweb</a></em></p>
+  <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
+    Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
+  </p>
 </body></html>

--- a/wp-content/plugins/obti-booking/emails/customer-cancelled.php
+++ b/wp-content/plugins/obti-booking/emails/customer-cancelled.php
@@ -8,5 +8,7 @@ $time  = get_post_meta($booking_id,'_obti_time', true);
 <html><body style="font-family:Inter,Arial,sans-serif;background:#ffffff;padding:16px;">
   <h2>Booking Cancelled</h2>
   <p>Hi <?php echo esc_html($name); ?>, your booking #<?php echo intval($booking_id); ?> for <?php echo esc_html($date.' '.$time); ?> has been cancelled. A refund has been initiated.</p>
-  <p><em>Powered by <a href="https://www.totaliweb.com">Totaliweb</a></em></p>
+  <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
+    Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
+  </p>
 </body></html>

--- a/wp-content/plugins/obti-booking/emails/customer-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-confirmed.php
@@ -30,9 +30,9 @@ $link = $account_page_id ? add_query_arg(['token'=>$token,'email'=>$email], get_
         <p style="margin-top:12px;color:#111827">Manage or cancel (up to 72h before): <a href="<?php echo esc_url($link); ?>" style="color:#16a34a">My Bookings</a></p>
         <p style="margin-top:12px;color:#374151;font-size:14px">In case of bad weather or cancellation we offer a full refund or the possibility to reschedule.</p>
       </div>
-      <div style="background:#f3f4f6;color:#6b7280;padding:16px 24px;text-align:center;font-size:12px">
-        Powered by <a href="https://www.totaliweb.com" style="color:#16a34a;text-decoration:none">Totaliweb</a>
-      </div>
+      <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
+        Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
+      </p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add Totaliweb attribution footer to all booking email templates

## Testing
- `php -l wp-content/plugins/obti-booking/emails/admin-confirmed.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-cancelled.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-confirmed.php`


------
https://chatgpt.com/codex/tasks/task_e_689fc27455388333a7b9d0839257e44b