### PR TITLE
feat: localize chatbot strings

### DIFF
--- a/wp-content/themes/obti/assets/js/chatbot.js
+++ b/wp-content/themes/obti/assets/js/chatbot.js
@@ -3,6 +3,7 @@
     var wrap = document.getElementById('obti-chatbot');
     if(!wrap) return;
     var cfg = window.obtiConfig || {};
+    var tr = window.obti_translations || {};
     var apiKey = wrap.getAttribute('data-api-key') || cfg.chatbot_api_key || '';
 
     var toggleBtn = document.createElement('button');
@@ -14,13 +15,13 @@
     box.className = 'obti-chatbot-box hidden';
     box.innerHTML = '\
 <div class="obti-chat-header">\
-  <span>Chatbot</span>\
+  <span>' + (tr.title || 'Chatbot') + '</span>\
   <button type="button" class="obti-chat-close">&times;</button>\
 </div>\
 <div class="obti-chat-messages"></div>\
 <form class="obti-chat-form">\
-  <input type="text" placeholder="Chiedi..." class="obti-chat-input" />\
-  <button type="submit">Invia</button>\
+  <input type="text" placeholder="' + (tr.placeholder || 'Ask...') + '" class="obti-chat-input" />\
+  <button type="submit">' + (tr.send || 'Send') + '</button>\
 </form>';
     document.body.appendChild(box);
 
@@ -43,6 +44,18 @@
       messages.scrollTop = messages.scrollHeight;
     }
 
+    function changeLanguage(obj){
+      tr = obj || tr;
+      var header = box.querySelector('.obti-chat-header span');
+      var input = box.querySelector('.obti-chat-input');
+      var submit = box.querySelector('.obti-chat-form button');
+      if(header && tr.title) header.textContent = tr.title;
+      if(input && tr.placeholder) input.placeholder = tr.placeholder;
+      if(submit && tr.send) submit.textContent = tr.send;
+    }
+
+    changeLanguage(tr);
+
     form.addEventListener('submit', function(e){
       e.preventDefault();
       var input = box.querySelector('.obti-chat-input');
@@ -56,8 +69,8 @@
         body: JSON.stringify({ message: text })
       })
       .then(function(r){ return r.json(); })
-      .then(function(d){ addMessage('bot', d.answer || 'Nessuna risposta'); })
-      .catch(function(){ addMessage('bot', 'Errore di rete'); });
+      .then(function(d){ addMessage('bot', d.answer || tr.no_answer || 'No response'); })
+      .catch(function(){ addMessage('bot', tr.network_error || 'Network error'); });
     });
   });
 })();

--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -29,6 +29,15 @@ add_action('wp_enqueue_scripts', function(){
         'mapbox_token'    => get_theme_mod('mapbox_token'),
         'chatbot_api_key' => get_theme_mod('chatbot_api_key'),
     ]);
+
+    // Localize translations
+    wp_localize_script('obti-chatbot', 'obti_translations', [
+        'title'         => __('Chatbot', 'obti'),
+        'placeholder'   => __('Ask...', 'obti'),
+        'send'          => __('Send', 'obti'),
+        'no_answer'     => __('No response', 'obti'),
+        'network_error' => __('Network error', 'obti'),
+    ]);
 });
 
 // Add a small script to init lucide icons after DOM ready


### PR DESCRIPTION
## Summary
- localize chatbot interface strings through `wp_localize_script`
- consume PHP-provided translations in `chatbot.js` via `changeLanguage`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_689fc3d57554833385606af574eb3ffe