### PR TITLE
feat: add auth menu and scroll header

### DIFF
--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -31,14 +31,19 @@ add_action('wp_enqueue_scripts', function(){
     ]);
 
     // Localize translations
-    wp_localize_script('obti-chatbot', 'obti_translations', [
-        'title'         => __('Chatbot', 'obti'),
-        'placeholder'   => __('Ask...', 'obti'),
-        'send'          => __('Send', 'obti'),
-        'no_answer'     => __('No response', 'obti'),
-        'network_error' => __('Network error', 'obti'),
-    ]);
-});
+      wp_localize_script('obti-chatbot', 'obti_translations', [
+          'title'         => __('Chatbot', 'obti'),
+          'placeholder'   => __('Ask...', 'obti'),
+          'send'          => __('Send', 'obti'),
+          'no_answer'     => __('No response', 'obti'),
+          'network_error' => __('Network error', 'obti'),
+      ]);
+
+      // Dropdown behaviour for user menu
+      wp_register_script('obti-header-dropdown', '', [], null, true);
+      wp_enqueue_script('obti-header-dropdown');
+      wp_add_inline_script('obti-header-dropdown', "document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('[data-dropdown-toggle]').forEach(function(btn){btn.addEventListener('click',function(){var id=btn.getAttribute('data-dropdown-toggle');var menu=document.getElementById(id);if(menu){menu.classList.toggle('hidden');}});});});");
+  });
 
 // Add a small script to init lucide icons after DOM ready
 add_action('wp_footer', function(){

--- a/wp-content/themes/obti/header.php
+++ b/wp-content/themes/obti/header.php
@@ -7,7 +7,7 @@
 <?php wp_head(); ?>
 </head>
 <body <?php body_class('bg-gray-50 text-gray-800'); ?>>
-<header id="site-header" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300 bg-white">
+<header id="site-header" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300 bg-transparent">
   <div class="container mx-auto px-6 py-4 flex justify-between items-center">
     <a class="text-2xl font-bold text-gray-800" href="<?php echo esc_url(home_url('/')); ?>">
       OpenBusTour<span class="theme-primary">Ischia</span>.com
@@ -46,6 +46,25 @@
         <a href="#" class="hover:text-theme-primary">IT</a>
       </div>
       <a href="#" class="bg-theme-primary text-white px-4 py-2 rounded">Book Now</a>
+      <?php if (is_user_logged_in()) : $current_user = wp_get_current_user(); ?>
+      <div class="relative">
+        <button class="flex items-center space-x-2" data-dropdown-toggle="user-dropdown-desktop">
+          <?php echo get_avatar($current_user->ID, 32, '', '', ['class' => 'rounded-full']); ?>
+          <i data-lucide="chevron-down" class="w-4 h-4"></i>
+        </button>
+        <ul id="user-dropdown-desktop" class="hidden absolute right-0 mt-2 w-48 bg-white border rounded shadow-md">
+          <li><a href="<?php echo esc_url(admin_url()); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(get_edit_profile_url($current_user->ID)); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(home_url('/bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
+        </ul>
+      </div>
+      <?php else : ?>
+      <div class="flex items-center space-x-4 text-sm font-semibold">
+        <a href="<?php echo esc_url(wp_login_url()); ?>" class="hover:text-theme-primary"><?php _e('Login', 'obti'); ?></a>
+        <a href="<?php echo esc_url(wp_registration_url()); ?>" class="hover:text-theme-primary"><?php _e('Register', 'obti'); ?></a>
+      </div>
+      <?php endif; ?>
     </div>
     <button id="mobile-menu-button" class="md:hidden"><i data-lucide="menu"></i></button>
   </div>
@@ -58,6 +77,26 @@
       </div>
       <a href="#" class="bg-theme-primary text-white px-4 py-2 rounded">Book Now</a>
     </div>
+    <?php if (is_user_logged_in()) : $current_user = wp_get_current_user(); ?>
+    <div class="py-4 border-b">
+      <button class="flex items-center space-x-2 w-full" data-dropdown-toggle="user-dropdown-mobile">
+        <?php echo get_avatar($current_user->ID, 32, '', '', ['class' => 'rounded-full']); ?>
+        <span class="flex-1 text-left"><?php echo esc_html($current_user->display_name); ?></span>
+        <i data-lucide="chevron-down" class="w-4 h-4"></i>
+      </button>
+      <ul id="user-dropdown-mobile" class="hidden mt-2 w-full bg-white border rounded shadow-md">
+        <li><a href="<?php echo esc_url(admin_url()); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(get_edit_profile_url($current_user->ID)); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(home_url('/bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
+      </ul>
+    </div>
+    <?php else : ?>
+    <div class="flex items-center justify-center space-x-6 py-4 border-b text-sm font-semibold">
+      <a href="<?php echo esc_url(wp_login_url()); ?>" class="hover:text-theme-primary"><?php _e('Login', 'obti'); ?></a>
+      <a href="<?php echo esc_url(wp_registration_url()); ?>" class="hover:text-theme-primary"><?php _e('Register', 'obti'); ?></a>
+    </div>
+    <?php endif; ?>
     <?php
       $mobile_socials = [
         'facebook'  => get_theme_mod('social_facebook'),

--- a/wp-content/themes/obti/style.css
+++ b/wp-content/themes/obti/style.css
@@ -7,3 +7,8 @@ Description: Minimal base theme for Elementor + OBTI Booking. Tailwind via CDN f
 Version: 1.0.0
 Text Domain: obti
 */
+
+.header-scrolled {
+  background-color: #ffffff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- make header transparent and add scroll class styling
- integrate user auth dropdown with login/register fallback
- enqueue dropdown toggle script and sync mobile menu

## Testing
- `php -l wp-content/themes/obti/header.php`
- `php -l wp-content/themes/obti/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a052bfdb5c83338a5cb817294e7d60