### PR TITLE
Add header auth dropdown script

### DIFF
--- a/wp-content/themes/obti/assets/js/header-auth.js
+++ b/wp-content/themes/obti/assets/js/header-auth.js
@@ -1,0 +1,26 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    var dropdowns = [];
+    document.querySelectorAll('[data-dropdown-toggle]').forEach(function(btn){
+      var id = btn.getAttribute('data-dropdown-toggle');
+      var menu = document.getElementById(id);
+      if (!menu) return;
+      dropdowns.push({btn: btn, menu: menu});
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        dropdowns.forEach(function(obj){ if (obj.menu !== menu) obj.menu.classList.add('hidden'); });
+        menu.classList.toggle('hidden');
+      });
+    });
+    document.addEventListener('click', function(e){
+      dropdowns.forEach(function(obj){
+        if (!obj.menu.classList.contains('hidden') &&
+            !obj.menu.contains(e.target) &&
+            !obj.btn.contains(e.target)){
+          obj.menu.classList.add('hidden');
+        }
+      });
+    });
+  });
+})();

--- a/wp-content/themes/obti/functions.php
+++ b/wp-content/themes/obti/functions.php
@@ -40,9 +40,7 @@ add_action('wp_enqueue_scripts', function(){
       ]);
 
       // Dropdown behaviour for user menu
-      wp_register_script('obti-header-dropdown', '', [], null, true);
-      wp_enqueue_script('obti-header-dropdown');
-      wp_add_inline_script('obti-header-dropdown', "document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('[data-dropdown-toggle]').forEach(function(btn){btn.addEventListener('click',function(){var id=btn.getAttribute('data-dropdown-toggle');var menu=document.getElementById(id);if(menu){menu.classList.toggle('hidden');}});});});");
+      wp_enqueue_script('obti-header-auth', get_template_directory_uri() . '/assets/js/header-auth.js', [], '1.0.0', true);
   });
 
 // Add a small script to init lucide icons after DOM ready


### PR DESCRIPTION
## Summary
- add header-auth.js to manage avatar dropdowns and close them on outside clicks
- enqueue header auth script globally via functions.php

## Testing
- `php -l wp-content/themes/obti/functions.php`
- `node --check wp-content/themes/obti/assets/js/header-auth.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a05cdc33148333ab53392f29cf8aeb