### PR TITLE
Sanitize times setting as array

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -55,7 +55,18 @@ class OBTI_Admin_Settings_Page {
         add_submenu_page('obti-booking', __('Transfers Totaliweb','obti'), __('Transfers Totaliweb','obti'), 'manage_options', 'obti-transfers', ['OBTI_Transfers','render']);
     }
     public static function register(){
-        register_setting('obti_settings_group', 'obti_settings');
+        register_setting('obti_settings_group', 'obti_settings', [
+            'sanitize_callback' => [__CLASS__, 'sanitize']
+        ]);
+    }
+
+    public static function sanitize($value){
+        $raw_times = $_POST['obti_settings']['times'] ?? [];
+        if (is_string($raw_times)) {
+            $raw_times = explode(',', $raw_times);
+        }
+        $value['times'] = array_map('trim', (array) $raw_times);
+        return $value;
     }
     public static function render(){
         $o = OBTI_Settings::get_all();
@@ -75,7 +86,7 @@ class OBTI_Admin_Settings_Page {
               <tr><th><?php esc_html_e('Tour duration (min)','obti'); ?></th>
                 <td><input type="number" name="obti_settings[duration_min]" value="<?php echo esc_attr($o['duration_min']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Times (HH:MM, comma separated)','obti'); ?></th>
-                <td><input type="text" name="obti_settings[times]" value="<?php echo esc_attr(implode(',', $o['times'])); ?>"></td></tr>
+                <td><input type="text" name="obti_settings[times]" value="<?php echo esc_attr(is_array($o['times']) ? implode(',', $o['times']) : implode(',', (array) $o['times'])); ?>"></td></tr>
               <tr><th><?php esc_html_e('Cutoff (minutes before start)','obti'); ?></th>
                 <td><input type="number" name="obti_settings[cutoff_min]" value="<?php echo esc_attr($o['cutoff_min']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Refund window (hours before start)','obti'); ?></th>


### PR DESCRIPTION
## Summary
- ensure `obti_settings[times]` is stored as an array by sanitizing comma-separated input
- guard times field rendering against non-array values

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0674fc4848333b61d11f0d45a8b1c