### PR TITLE
Handle WP_REST_Response in availability check

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -134,6 +134,7 @@ class OBTI_REST {
 
         // Availability check
         $av = self::availability(new WP_REST_Request('GET', '/obti/v1/availability?date='.$date));
+        $av = $av instanceof WP_REST_Response ? $av->get_data() : $av;
         if (is_wp_error($av)) return new WP_REST_Response(['error'=>'availability_error'], 400);
         $found = null;
         foreach($av['slots'] as $slot){ if ($slot['time'] === $time) { $found = $slot; break; } }


### PR DESCRIPTION
## Summary
- Normalize availability lookup to an array when a WP_REST_Response is returned

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0693789648333922a79156707afbb