### PR TITLE
Prefill booking form for logged-in users

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
@@ -17,6 +17,18 @@
     var availLabel = qs('#obti-availability-label');
     var payBtn = qs('#obti-pay-btn');
 
+    var userId = form.getAttribute('data-user');
+    if (userId) {
+      if (name) {
+        name.value = form.getAttribute('data-name') || name.value;
+        if (name.parentNode) name.parentNode.style.display = 'none';
+      }
+      if (email) {
+        email.value = form.getAttribute('data-email') || email.value;
+        if (email.parentNode) email.parentNode.style.display = 'none';
+      }
+    }
+
     flatpickr('#date-picker', { minDate: 'today', dateFormat: 'Y-m-d' });
 
     function updateAvailability(){

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -23,6 +23,15 @@ class Booking extends Widget_Base {
         wp_enqueue_style('flatpickr');
         wp_enqueue_script('obti-booking-widget');
         $ajax = esc_url( rest_url('obti/v1') );
+        $user_id = 0;
+        $user_name = '';
+        $user_email = '';
+        if ( is_user_logged_in() ) {
+            $u = wp_get_current_user();
+            $user_id = $u->ID;
+            $user_name = $u->display_name;
+            $user_email = $u->user_email;
+        }
         ?>
         <section id="booking" class="py-20 bg-gray-100">
           <div class="container mx-auto px-6">
@@ -32,7 +41,7 @@ class Booking extends Widget_Base {
             </div>
             <div class="max-w-4xl mx-auto bg-white rounded-2xl shadow-2xl overflow-hidden md:flex">
               <div class="md:w-1/2 p-8 md:p-12">
-                <form id="obti-booking-form" data-api="<?php echo $ajax; ?>">
+                <form id="obti-booking-form" data-api="<?php echo $ajax; ?>"<?php if ($user_id) { echo ' data-user="' . esc_attr($user_id) . '" data-name="' . esc_attr($user_name) . '" data-email="' . esc_attr($user_email) . '"'; } ?>>
                   <div class="space-y-6">
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Date','obti'); ?></label>
@@ -55,11 +64,11 @@ class Booking extends Widget_Base {
                     </div>
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Full Name','obti'); ?></label>
-                      <input type="text" name="name" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                      <input type="text" name="name" value="<?php echo esc_attr( $user_name ); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Email','obti'); ?></label>
-                      <input type="email" name="email" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                      <input type="email" name="email" value="<?php echo esc_attr( $user_email ); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                   </div>
                 </form>


### PR DESCRIPTION
## Summary
- Prepopulate booking form with logged-in user's name and email.
- Hide name/email fields when user is known via data-user attribute.
- Associate bookings with WordPress users by creating or finding user on checkout.

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06d7787888333812d9317c8345524