### PR TITLE
Add customer role and restrict admin access

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-admin.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-admin.php
@@ -3,8 +3,23 @@ if (!defined('ABSPATH')) { exit; }
 
 class OBTI_Admin {
     public static function init(){
+        add_action('admin_init', [__CLASS__, 'redirect_non_privileged'], 1);
         add_action('admin_init', [__CLASS__, 'add_meta']);
+        add_action('after_setup_theme', [__CLASS__, 'maybe_hide_admin_bar']);
         add_action('save_post_obti_booking', [__CLASS__, 'save_meta'], 10, 2);
+    }
+    public static function redirect_non_privileged(){
+        if (wp_doing_ajax()) return;
+        if (!current_user_can('manage_options')) {
+            wp_redirect(home_url());
+            exit;
+        }
+    }
+    public static function maybe_hide_admin_bar(){
+        $user = wp_get_current_user();
+        if (in_array('obti_customer', (array) $user->roles, true)) {
+            show_admin_bar(false);
+        }
     }
     public static function add_meta(){
         add_meta_box('obti_booking_meta', __('Booking Details','obti'), [__CLASS__,'render_meta'], 'obti_booking', 'normal', 'high');

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -34,6 +34,7 @@ function obti_get_page_id( $title ) {
 
 // Activation: create pages + schedule cron + flush rewrite
 register_activation_hook(__FILE__, function(){
+    add_role('obti_customer', 'OBTI Customer', ['read' => true]);
     if (!wp_next_scheduled('obti_cleanup_holds')) { wp_schedule_event(time()+300, 'five_minutes', 'obti_cleanup_holds'); }
     OBTI_Booking_CPT::register();
     flush_rewrite_rules();


### PR DESCRIPTION
## Summary
- create `obti_customer` role on plugin activation
- redirect non-admin users from `wp-admin`
- hide admin bar for `obti_customer` role

## Testing
- `php -l wp-content/plugins/obti-booking/obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0702638d4833395f95084b5bddfa0