### PR TITLE
Use frontend dashboard links and improve dropdown handling

### DIFF
--- a/wp-content/themes/obti/assets/js/header-auth.js
+++ b/wp-content/themes/obti/assets/js/header-auth.js
@@ -12,6 +12,11 @@
         dropdowns.forEach(function(obj){ if (obj.menu !== menu) obj.menu.classList.add('hidden'); });
         menu.classList.toggle('hidden');
       });
+      menu.querySelectorAll('a').forEach(function(link){
+        link.addEventListener('click', function(){
+          menu.classList.add('hidden');
+        });
+      });
     });
     document.addEventListener('click', function(e){
       dropdowns.forEach(function(obj){

--- a/wp-content/themes/obti/header.php
+++ b/wp-content/themes/obti/header.php
@@ -53,9 +53,9 @@
           <i data-lucide="chevron-down" class="w-4 h-4"></i>
         </button>
         <ul id="user-dropdown-desktop" class="hidden absolute right-0 mt-2 w-48 bg-white border rounded shadow-md">
-          <li><a href="<?php echo esc_url(admin_url()); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
-          <li><a href="<?php echo esc_url(get_edit_profile_url($current_user->ID)); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
-          <li><a href="<?php echo esc_url(home_url('/bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(home_url('/dashboard')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(home_url('/dashboard?tab=bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
           <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
         </ul>
       </div>
@@ -85,9 +85,9 @@
         <i data-lucide="chevron-down" class="w-4 h-4"></i>
       </button>
       <ul id="user-dropdown-mobile" class="hidden mt-2 w-full bg-white border rounded shadow-md">
-        <li><a href="<?php echo esc_url(admin_url()); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
-        <li><a href="<?php echo esc_url(get_edit_profile_url($current_user->ID)); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
-        <li><a href="<?php echo esc_url(home_url('/bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(home_url('/dashboard')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(home_url('/dashboard?tab=bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
         <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Replace WP admin links with frontend dashboard routes for dashboard, profile and booking options
- Auto-hide dropdown menus when selecting an item to keep toggling smooth

## Testing
- `npm install`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a0725bb3b883338f0201b0b4450e41