### PR TITLE
Support ranged capacity overrides with remote deletion

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -23,7 +23,7 @@ class OBTI_Settings {
             'connect_enabled' => 0,
             'connect_platform_secret_key' => '',
             'connect_client_account_id' => '',
-            // Capacity overrides map: 'YYYY-MM-DD HH:MM' => capacity int
+            // Capacity overrides array: [ ['id'=>uniqid(),'from'=>'YYYY-MM-DD','to'=>'YYYY-MM-DD','times'=>['HH:MM'], 'capacity'=>int] ]
             'capacity_overrides' => []
         ];
     }
@@ -127,37 +127,126 @@ class OBTI_Admin_Settings_Page {
     }
 
     public static function render_overrides(){
-        if (isset($_POST['obti_override_nonce']) && wp_verify_nonce($_POST['obti_override_nonce'], 'obti_overrides')){
-            $map = OBTI_Settings::get('capacity_overrides', []);
-            $date = sanitize_text_field($_POST['date'] ?? '');
-            $time = sanitize_text_field($_POST['time'] ?? '');
+        $overrides = OBTI_Settings::get('capacity_overrides', []);
+        // Backwards compatibility: convert old key=>capacity map
+        if ($overrides && $overrides && (!is_array(reset($overrides)) || !isset(reset($overrides)['id']))) {
+            $converted = [];
+            foreach($overrides as $k=>$v){
+                $parts = explode(' ', $k);
+                $d = $parts[0] ?? '';
+                $t = $parts[1] ?? '';
+                if ($d && $t){
+                    $converted[] = ['id'=>uniqid(),'from'=>$d,'to'=>$d,'times'=>[$t],'capacity'=>intval($v)];
+                }
+            }
+            $overrides = $converted;
+            OBTI_Settings::update('capacity_overrides', $overrides);
+        }
+
+        // Delete
+        if (isset($_GET['action'], $_GET['id']) && $_GET['action'] === 'delete') {
+            $del_id = sanitize_text_field($_GET['id']);
+            if (wp_verify_nonce($_GET['_wpnonce'] ?? '', 'obti_override_delete_'.$del_id)) {
+                $overrides = array_values(array_filter($overrides, function($o) use ($del_id){ return ($o['id'] ?? '') !== $del_id; }));
+                OBTI_Settings::update('capacity_overrides', $overrides);
+                echo '<div class="updated"><p>'.esc_html__('Deleted override.','obti').'</p></div>';
+            }
+        }
+
+        // Save / Update
+        if (isset($_POST['obti_override_nonce']) && wp_verify_nonce($_POST['obti_override_nonce'], 'obti_override_save')){
+            $id   = sanitize_text_field($_POST['id'] ?? '');
+            $from = sanitize_text_field($_POST['from'] ?? '');
+            $to   = sanitize_text_field($_POST['to'] ?? '');
+            $times_raw = (array)($_POST['times'] ?? []);
+            $times = array_filter(array_map('sanitize_text_field', $times_raw));
             $cap  = max(0, intval($_POST['capacity'] ?? 0));
-            if ($date && $time){
-                $map[$date.' '.$time] = $cap;
-                OBTI_Settings::update('capacity_overrides', $map);
+            if ($from && !$to) $to = $from;
+            if ($from && $to){
+                if (!$id) $id = uniqid();
+                $record = [
+                    'id' => $id,
+                    'from' => $from,
+                    'to' => $to,
+                    'times' => $times,
+                    'capacity' => $cap
+                ];
+                $found = false;
+                foreach($overrides as $idx=>$o){
+                    if (($o['id'] ?? '') === $id){ $overrides[$idx] = $record; $found = true; break; }
+                }
+                if (!$found) $overrides[] = $record;
+                OBTI_Settings::update('capacity_overrides', $overrides);
                 echo '<div class="updated"><p>'.esc_html__('Saved override.','obti').'</p></div>';
             }
         }
-        $map = OBTI_Settings::get('capacity_overrides', []);
+
+        $edit = null;
+        if (isset($_GET['action'], $_GET['id']) && $_GET['action'] === 'edit') {
+            $edit_id = sanitize_text_field($_GET['id']);
+            foreach ($overrides as $o) { if (($o['id'] ?? '') === $edit_id) { $edit = $o; break; } }
+        }
+
         ?>
         <div class="wrap">
           <h1><?php esc_html_e('Capacity Overrides','obti'); ?></h1>
-          <form method="post">
-            <?php wp_nonce_field('obti_overrides','obti_override_nonce'); ?>
-            <p>
-              <label><?php esc_html_e('Date','obti'); ?> <input type="date" name="date" required></label>
-              <label><?php esc_html_e('Time','obti'); ?> <input type="time" name="time" required></label>
-              <label><?php esc_html_e('Capacity','obti'); ?> <input type="number" name="capacity" required></label>
-              <button class="button button-primary"><?php esc_html_e('Add/Update','obti'); ?></button>
-            </p>
-          </form>
           <h2><?php esc_html_e('Existing overrides','obti'); ?></h2>
-          <table class="widefat"><thead><tr><th><?php esc_html_e('Key','obti'); ?></th><th><?php esc_html_e('Capacity','obti'); ?></th></tr></thead><tbody>
-          <?php foreach($map as $k=>$v): ?>
-            <tr><td><?php echo esc_html($k); ?></td><td><?php echo esc_html($v); ?></td></tr>
+          <table class="widefat"><thead><tr><th><?php esc_html_e('From','obti'); ?></th><th><?php esc_html_e('To','obti'); ?></th><th><?php esc_html_e('Times','obti'); ?></th><th><?php esc_html_e('Capacity','obti'); ?></th><th><?php esc_html_e('Actions','obti'); ?></th></tr></thead><tbody>
+          <?php foreach($overrides as $o): ?>
+            <tr>
+              <td><?php echo esc_html($o['from']); ?></td>
+              <td><?php echo esc_html($o['to']); ?></td>
+              <td><?php echo esc_html(implode(', ', $o['times'] ?? [])); ?></td>
+              <td><?php echo esc_html($o['capacity']); ?></td>
+              <td>
+                <a href="<?php echo esc_url(add_query_arg(['page'=>'obti-capacity','action'=>'edit','id'=>$o['id']])); ?>"><?php esc_html_e('Edit','obti'); ?></a>
+                |
+                <a href="<?php echo esc_url(wp_nonce_url(add_query_arg(['page'=>'obti-capacity','action'=>'delete','id'=>$o['id']]), 'obti_override_delete_'.$o['id'])); ?>" onclick="return confirm('<?php echo esc_js(__('Delete override?','obti')); ?>');"><?php esc_html_e('Delete','obti'); ?></a>
+              </td>
+            </tr>
           <?php endforeach; ?>
           </tbody></table>
+
+          <h2><?php echo $edit ? esc_html__('Edit override','obti') : esc_html__('Add override','obti'); ?></h2>
+          <form method="post">
+            <?php wp_nonce_field('obti_override_save','obti_override_nonce'); ?>
+            <?php if($edit): ?><input type="hidden" name="id" value="<?php echo esc_attr($edit['id']); ?>"><?php endif; ?>
+            <p>
+              <label><?php esc_html_e('From','obti'); ?> <input type="date" name="from" value="<?php echo esc_attr($edit['from'] ?? ''); ?>" required></label>
+              <label><?php esc_html_e('To','obti'); ?> <input type="date" name="to" value="<?php echo esc_attr($edit['to'] ?? ''); ?>"></label>
+              <label><?php esc_html_e('Capacity','obti'); ?> <input type="number" name="capacity" value="<?php echo esc_attr($edit['capacity'] ?? ''); ?>" required></label>
+            </p>
+            <div id="obti-times-wrapper">
+            <?php $times = $edit ? ($edit['times'] ?? []) : [''];
+            if (empty($times)) $times = [''];
+            foreach($times as $t): ?>
+              <p><input type="time" name="times[]" value="<?php echo esc_attr($t); ?>"> <button type="button" class="button obti-remove-time"><?php esc_html_e('Remove','obti'); ?></button></p>
+            <?php endforeach; ?>
+            </div>
+            <p><button type="button" class="button" id="obti-add-time"><?php esc_html_e('Add time','obti'); ?></button></p>
+            <p><button class="button button-primary"><?php echo $edit ? esc_html__('Update','obti') : esc_html__('Add override','obti'); ?></button></p>
+          </form>
         </div>
+        <script>
+        (function(){
+            var addBtn = document.getElementById('obti-add-time');
+            if(addBtn){
+                addBtn.addEventListener('click', function(e){
+                    e.preventDefault();
+                    var wrap = document.getElementById('obti-times-wrapper');
+                    var p = document.createElement('p');
+                    p.innerHTML = '<input type="time" name="times[]"> <button type="button" class="button obti-remove-time"><?php echo esc_js(__('Remove','obti')); ?></button>';
+                    wrap.appendChild(p);
+                });
+                document.addEventListener('click', function(e){
+                    if(e.target && e.target.classList.contains('obti-remove-time')){
+                        e.preventDefault();
+                        e.target.parentNode.remove();
+                    }
+                });
+            }
+        })();
+        </script>
         <?php
     }
 }


### PR DESCRIPTION
## Summary
- represent capacity overrides as from/to ranges with multiple times and capacity
- add admin UI to create, edit, and delete overrides with dynamic time rows
- apply first matching override when computing availability
- expose DELETE /obti/v1/capacity-override/{id} endpoint

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a08c9078c48333aa6c0ff5c2efd0bd