### PR TITLE
Sanitize and render booking times safely

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -65,7 +65,10 @@ class OBTI_Admin_Settings_Page {
         if (is_string($raw_times)) {
             $raw_times = explode(',', $raw_times);
         }
-        $value['times'] = array_map('trim', (array) $raw_times);
+        $raw_times = array_map('trim', (array)$raw_times);
+        $value['times'] = array_values(array_filter($raw_times, function ($t) {
+            return preg_match('/^(?:[01]\d|2[0-3]):[0-5]\d$/', $t);
+        }));
         return $value;
     }
     public static function render(){
@@ -86,7 +89,7 @@ class OBTI_Admin_Settings_Page {
               <tr><th><?php esc_html_e('Tour duration (min)','obti'); ?></th>
                 <td><input type="number" name="obti_settings[duration_min]" value="<?php echo esc_attr($o['duration_min']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Times (HH:MM, comma separated)','obti'); ?></th>
-                <td><input type="text" name="obti_settings[times]" value="<?php echo esc_attr(is_array($o['times']) ? implode(',', $o['times']) : implode(',', (array) $o['times'])); ?>"></td></tr>
+                <td><input type="text" name="obti_settings[times]" value="<?php echo esc_attr(implode(',', (array)$o['times'])); ?>"></td></tr>
               <tr><th><?php esc_html_e('Cutoff (minutes before start)','obti'); ?></th>
                 <td><input type="number" name="obti_settings[cutoff_min]" value="<?php echo esc_attr($o['cutoff_min']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Refund window (hours before start)','obti'); ?></th>


### PR DESCRIPTION
## Summary
- Trim and validate booking times during settings sanitization, discarding non HH:MM entries
- Render saved times by imploding a cast array to prevent type mismatches

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -r 'define("ABSPATH",1); function add_action(){} function add_menu_page(){} function add_submenu_page(){} function register_setting(){} $_POST["obti_settings"]["times"]="10:00"; require "wp-content/plugins/obti-booking/includes/class-obti-settings.php"; var_export(OBTI_Admin_Settings_Page::sanitize([]));'`
- `php -r 'define("ABSPATH",1); function add_action(){} function add_menu_page(){} function add_submenu_page(){} function register_setting(){} $_POST["obti_settings"]["times"]="10:00, 13:30"; require "wp-content/plugins/obti-booking/includes/class-obti-settings.php"; var_export(OBTI_Admin_Settings_Page::sanitize([]));'`
- `php -r 'define("ABSPATH",1); function add_action(){} function add_menu_page(){} function add_submenu_page(){} function register_setting(){} $_POST["obti_settings"]["times"]="10:00, 25:00, abc"; require "wp-content/plugins/obti-booking/includes/class-obti-settings.php"; var_export(OBTI_Admin_Settings_Page::sanitize([]));'`


------
https://chatgpt.com/codex/tasks/task_e_68a08e4fcf3083339dcd218151ac09bb