### PR TITLE
Preserve booking date placeholder

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
@@ -30,7 +30,7 @@
       }
     }
 
-    flatpickr('#date-picker', { minDate: 'today', dateFormat: 'Y-m-d' });
+    flatpickr('#date-picker', { allowInput: true, minDate: 'today', dateFormat: 'Y-m-d' });
 
     function updateAvailability(){
       if (!date.value) return;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -45,7 +45,7 @@ class Booking extends Widget_Base {
                   <div class="space-y-6">
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Date','obti'); ?></label>
-                      <input id="date-picker" name="date" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                      <input id="date-picker" name="date" placeholder="<?php esc_attr_e('Select date','obti'); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Tour Time','obti'); ?></label>


### PR DESCRIPTION
## Summary
- Keep the booking form date field's placeholder text
- Configure Flatpickr to allow user input and retain placeholder

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php`
- `node --check wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js`
- `node flatpickr_test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0938ac26c83339acb8acb3440cd6d