### PR TITLE
Remove capacity overrides

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -26,11 +26,6 @@ class OBTI_REST {
             'callback' => [__CLASS__, 'bookings'],
             'permission_callback' => [__CLASS__, 'auth']
         ]);
-        register_rest_route('obti/v1', '/capacity-override/(?P<id>[\w-]+)', [
-            'methods' => 'DELETE',
-            'callback' => [__CLASS__, 'delete_capacity_override'],
-            'permission_callback' => [__CLASS__, 'auth']
-        ]);
         register_rest_route('obti/v1', '/bookings/(?P<id>\d+)/transfer', [
             'methods' => 'PATCH',
             'callback' => [__CLASS__, 'mark_transfer'],
@@ -67,36 +62,9 @@ class OBTI_REST {
         $capacity_default = intval($o['capacity']);
         $cutoff = intval($o['cutoff_min']);
         $tz = obti_wp_timezone_string();
-        $overrides = OBTI_Settings::get('capacity_overrides', []);
-        if ($overrides && (!is_array(reset($overrides)) || !isset(reset($overrides)['id']))) {
-            $converted = [];
-            foreach($overrides as $k=>$v){
-                $parts = explode(' ', $k);
-                $d = $parts[0] ?? '';
-                $t = $parts[1] ?? '';
-                if ($d && $t){
-                    $converted[] = ['id'=>uniqid(),'from'=>$d,'to'=>$d,'times'=>[$t],'capacity'=>intval($v)];
-                }
-            }
-            $overrides = $converted;
-            OBTI_Settings::update('capacity_overrides', $overrides);
-        }
         $slots = [];
         foreach($times as $t){
             $capacity = $capacity_default;
-            if ($overrides && is_array($overrides)) {
-                foreach($overrides as $ov){
-                    $from = $ov['from'] ?? '';
-                    $to   = $ov['to'] ?? $from;
-                    $ov_times = $ov['times'] ?? [];
-                    if ($from && $to && $date >= $from && $date <= $to) {
-                        if (empty($ov_times) || in_array($t, $ov_times)) {
-                            $capacity = intval($ov['capacity']);
-                            break;
-                        }
-                    }
-                }
-            }
             // Sum booked seats
             $booked = self::sum_booked($date, $t);
             $available = max(0, $capacity - $booked);
@@ -284,26 +252,6 @@ class OBTI_REST {
         $status = sanitize_text_field($req->get_param('status') ?: 'yes');
         update_post_meta($id, '_obti_fee_transferred', $status);
         return ['id' => $id, 'transfer_status' => $status];
-    }
-
-    public static function delete_capacity_override($req){
-        $id = sanitize_text_field($req['id'] ?? '');
-        if (!$id) return new WP_REST_Response(['error'=>'not_found'], 404);
-        $overrides = OBTI_Settings::get('capacity_overrides', []);
-        $new = [];
-        $removed = false;
-        foreach($overrides as $ov){
-            if (($ov['id'] ?? '') === $id){
-                $removed = true;
-                continue;
-            }
-            $new[] = $ov;
-        }
-        if ($removed){
-            OBTI_Settings::update('capacity_overrides', $new);
-            return ['id'=>$id,'deleted'=>true];
-        }
-        return new WP_REST_Response(['error'=>'not_found'], 404);
     }
 
     public static function cancel($req){

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -22,6 +22,20 @@ require_once OBTI_PLUGIN_DIR . 'includes/class-obti-cron.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-admin.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-transfers.php';
 
+add_action('plugins_loaded', 'obti_maybe_upgrade');
+function obti_maybe_upgrade(){
+    $installed = get_option('obti_version');
+    if ($installed !== OBTI_VERSION){
+        delete_option('obti_capacity_overrides');
+        $settings = get_option('obti_settings', []);
+        if (isset($settings['capacity_overrides'])){
+            unset($settings['capacity_overrides']);
+            update_option('obti_settings', $settings);
+        }
+        update_option('obti_version', OBTI_VERSION);
+    }
+}
+
 function obti_get_page_id( $title ) {
     $q = new WP_Query([
         'post_type'      => 'page',


### PR DESCRIPTION
## Summary
- drop capacity override defaults and admin pages
- simplify REST API availability handling with no overrides
- add upgrade routine to purge old capacity override options

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `php -l wp-content/plugins/obti-booking/obti-booking.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0b03f548333bb7ff8683a23ab8e