### PR TITLE
Combine agency fee into service fee and show admin breakdown

### DIFF
--- a/wp-content/plugins/obti-booking/emails/admin-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/admin-confirmed.php
@@ -5,6 +5,8 @@ $email = get_post_meta($booking_id,'_obti_email', true);
 $date  = get_post_meta($booking_id,'_obti_date', true);
 $time  = get_post_meta($booking_id,'_obti_time', true);
 $qty   = (int) get_post_meta($booking_id,'_obti_qty', true);
+$service_fee = get_post_meta($booking_id,'_obti_service_fee', true);
+$agency_fee = get_post_meta($booking_id,'_obti_agency_fee', true);
 $total = get_post_meta($booking_id,'_obti_total', true);
 ?>
 <!doctype html>
@@ -14,6 +16,8 @@ $total = get_post_meta($booking_id,'_obti_total', true);
   <ul>
     <li>Date/Time: <?php echo esc_html($date.' '.$time); ?></li>
     <li>Tickets: <?php echo esc_html($qty); ?></li>
+    <li>Service fee: €<?php echo esc_html($service_fee); ?></li>
+    <li>Agency fee: €<?php echo esc_html($agency_fee); ?></li>
     <li>Total: €<?php echo esc_html($total); ?></li>
   </ul>
   <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">

--- a/wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php
@@ -42,6 +42,8 @@ class OBTI_Booking_CPT {
             $cols['date_time'] = __('Date/Time','obti');
             $cols['qty'] = __('Qty','obti');
             $cols['customer'] = __('Customer','obti');
+            $cols['service_fee'] = __('Service fee','obti');
+            $cols['agency_fee'] = __('Agency fee','obti');
             $cols['total'] = __('Total','obti');
             return $cols;
         });
@@ -52,6 +54,10 @@ class OBTI_Booking_CPT {
                 echo intval(get_post_meta($post_id,'_obti_qty', true));
             } elseif ($col === 'customer'){
                 echo esc_html(get_post_meta($post_id,'_obti_name', true).' <'.get_post_meta($post_id,'_obti_email', true).'>');
+            } elseif ($col === 'service_fee'){
+                echo '€'.esc_html(get_post_meta($post_id,'_obti_service_fee', true));
+            } elseif ($col === 'agency_fee'){
+                echo '€'.esc_html(get_post_meta($post_id,'_obti_agency_fee', true));
             } elseif ($col === 'total'){
                 echo '€'.esc_html(get_post_meta($post_id,'_obti_total', true));
             }

--- a/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
@@ -10,8 +10,9 @@ class OBTI_Checkout {
         $qty   = intval(get_post_meta($booking_id,'_obti_qty', true));
         $unit  = floatval(get_post_meta($booking_id,'_obti_unit_price', true));
         $subtotal = floatval(get_post_meta($booking_id,'_obti_subtotal', true));
-        $service_fee = floatval(get_post_meta($booking_id,'_obti_service_fee', true));
+        $base_service_fee = floatval(get_post_meta($booking_id,'_obti_service_fee', true));
         $agency_fee  = floatval(get_post_meta($booking_id,'_obti_agency_fee', true));
+        $service_fee = $base_service_fee + $agency_fee;
         $total = floatval(get_post_meta($booking_id,'_obti_total', true));
         $currency = strtolower(get_post_meta($booking_id,'_obti_currency', true) ?: 'eur');
 

--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -171,8 +171,9 @@ class OBTI_REST {
         $agency_fee_percent  = floatval(OBTI_Settings::get('agency_fee_percent', 2.5));
         $unit = $price;
         $subtotal = $unit * $qty;
-        $service_fee = round($subtotal * $service_fee_percent / 100, 2);
+        $service_fee = round($subtotal * $service_fee_percent / 100, 2); // base fee
         $agency_fee = round($subtotal * $agency_fee_percent / 100, 2);
+        $service_fee_total = $service_fee + $agency_fee;
 
         $title = sprintf(__('Booking %s %s — %s','obti'), $date, $time, $name);
         $post_id = wp_insert_post([
@@ -189,7 +190,7 @@ class OBTI_REST {
         update_post_meta($post_id, '_obti_subtotal', number_format($subtotal,2,'.',''));
         update_post_meta($post_id, '_obti_service_fee', number_format($service_fee,2,'.',''));
         update_post_meta($post_id, '_obti_agency_fee', number_format($agency_fee,2,'.',''));
-        update_post_meta($post_id, '_obti_total', number_format($subtotal + $service_fee,2,'.',''));
+        update_post_meta($post_id, '_obti_total', number_format($subtotal + $service_fee_total,2,'.',''));
         update_post_meta($post_id, '_obti_email', $email);
         update_post_meta($post_id, '_obti_name', $name);
         update_post_meta($post_id, '_obti_currency', $currency);
@@ -237,6 +238,7 @@ class OBTI_REST {
                 'time' => get_post_meta($id, '_obti_time', true),
                 'qty' => intval(get_post_meta($id, '_obti_qty', true)),
                 'total' => floatval(get_post_meta($id, '_obti_total', true)),
+                'service_fee' => floatval(get_post_meta($id, '_obti_service_fee', true)),
                 'agency_fee' => floatval(get_post_meta($id, '_obti_agency_fee', true)),
                 'transfer_status' => get_post_meta($id, '_obti_fee_transferred', true),
             ];


### PR DESCRIPTION
## Summary
- Calculate service fees as base plus agency fee and charge as one line item in Stripe
- Save agency and base service fees separately for analysis
- Display service and agency fees in admin emails and booking list

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-checkout.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php`
- `php -l wp-content/plugins/obti-booking/emails/admin-confirmed.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1ed753c833392ee6feb4b52b209