### PR TITLE
Add transient-based holds and payment reminder email

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-pending.php
+++ b/wp-content/plugins/obti-booking/emails/customer-pending.php
@@ -1,0 +1,10 @@
+<?php
+$booking_id = $booking_id ?? 0;
+$name  = get_post_meta($booking_id,'_obti_name', true);
+$date  = get_post_meta($booking_id,'_obti_date', true);
+$time  = get_post_meta($booking_id,'_obti_time', true);
+?>
+<p style="margin:0 0 16px 0;">Hi <?php echo esc_html($name); ?>,</p>
+<p style="margin:0 0 16px 0;">Your booking #<?php echo intval($booking_id); ?> for <?php echo esc_html($date.' '.$time); ?> is reserved for 30 minutes. Please complete payment to confirm your seat.</p>
+<p style="margin:0 0 16px 0;"><a href="<?php echo esc_url($checkout_url); ?>">Pay now</a></p>
+<p style="margin:0 0 16px 0;">If payment isn't completed in time, the reservation will be cancelled automatically.</p>

--- a/wp-content/plugins/obti-booking/includes/class-obti-cron.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-cron.php
@@ -9,17 +9,16 @@ class OBTI_Cron {
     // Remove expired holds
     public static function cleanup(){
         $q = new WP_Query([
-            'post_type'=>'obti_booking',
-            'post_status'=>['obti-pending'],
-            'posts_per_page'=>-1,
-            'fields'=>'ids',
-            'meta_query'=>[
-                ['key'=>'_obti_hold_expires','value'=>time(),'compare'=>'<','type'=>'NUMERIC']
-            ]
+            'post_type'   => 'obti_booking',
+            'post_status' => ['obti-pending'],
+            'posts_per_page' => -1,
+            'fields'      => 'ids'
         ]);
         foreach($q->posts as $id){
-            wp_update_post(['ID'=>$id, 'post_status'=>'obti-cancelled']);
-            update_post_meta($id,'_obti_cancel_reason','hold_expired');
+            if (false === get_transient('obti_hold_'.$id)){
+                wp_update_post(['ID'=>$id, 'post_status'=>'obti-cancelled']);
+                update_post_meta($id,'_obti_cancel_reason','hold_expired');
+            }
         }
     }
     // Move confirmed bookings to in_progress/completed based on time

--- a/wp-content/plugins/obti-booking/includes/class-obti-webhooks.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-webhooks.php
@@ -103,6 +103,13 @@ class OBTI_Webhooks {
         return ['received'=>true];
     }
 
+    public static function email_customer_pending($booking_id, $checkout_url){
+        $to = get_post_meta($booking_id,'_obti_email', true);
+        if (!$to) return;
+        $subject = sprintf(__('Complete your booking — #%d','obti'), $booking_id);
+        $html = self::render_email_template('customer-pending.php', $booking_id, ['checkout_url'=>$checkout_url]);
+        self::send_html_mail($to, $subject, $html);
+    }
     private static function email_customer_confirmed($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
@@ -117,9 +124,10 @@ class OBTI_Webhooks {
         self::send_html_mail($admin, $subject, $html);
     }
 
-    public static function render_email_template($template, $booking_id){
+    public static function render_email_template($template, $booking_id, $vars = []){
         $path = OBTI_PLUGIN_DIR . 'emails/' . $template;
         if (!file_exists($path)) return '';
+        extract($vars);
         ob_start();
         include $path;
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- Store a 30-minute transient when creating pending bookings and email customer with payment link
- Cancel pending bookings whose hold transient expired via 5-minute cron job
- Add email template for pending booking reminders

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-cron.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-webhooks.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-pending.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a4e3ee50833382071801e9bb9c24