### PR TITLE
Schedule booking completion and add review email

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-completed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-completed.php
@@ -1,0 +1,23 @@
+<?php
+$booking_id = $booking_id ?? 0;
+$name  = get_post_meta($booking_id,'_obti_name', true);
+$reviews_url = $reviews_url ?? '#';
+?>
+<!doctype html>
+<html>
+  <body style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px;">
+    <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb">
+      <div style="background:#16a34a;color:#fff;padding:20px 24px;">
+        <h1 style="margin:0;font-size:22px;">OpenBusTourIschia.com</h1>
+      </div>
+      <div style="padding:24px;">
+        <h2 style="margin:0 0 8px 0;"><?php esc_html_e('Grazie per aver viaggiato con noi','obti'); ?></h2>
+        <p style="margin:0 0 16px 0;"><?php echo esc_html($name); ?>, <?php esc_html_e('ci farebbe piacere una tua recensione.','obti'); ?></p>
+        <p style="margin:0 0 16px 0;"><a href="<?php echo esc_url($reviews_url); ?>" style="color:#16a34a;"><?php esc_html_e('Lascia una recensione su Google','obti'); ?></a></p>
+      </div>
+      <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
+        Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -19,6 +19,7 @@ class OBTI_Settings {
             'stripe_secret_key' => '',
             'stripe_publishable_key' => '',
             'stripe_webhook_secret' => '',
+            'google_reviews_url' => '',
             // Connect (optional - advanced)
             'connect_enabled' => 0,
             'connect_platform_secret_key' => '',
@@ -86,6 +87,9 @@ class OBTI_Admin_Settings_Page {
             $value[$k] = isset($value[$k]) ? sanitize_text_field($value[$k]) : $defaults[$k];
         }
 
+        // URL settings
+        $value['google_reviews_url'] = isset($value['google_reviews_url']) ? esc_url_raw($value['google_reviews_url']) : $defaults['google_reviews_url'];
+
         // Times array: comma separated HH:MM values
         $raw_times = $_POST['obti_settings']['times'] ?? [];
         if (is_string($raw_times)) {
@@ -141,8 +145,10 @@ class OBTI_Admin_Settings_Page {
                 <td><input type="text" size="60" name="obti_settings[stripe_secret_key]" value="<?php echo esc_attr($o['stripe_secret_key']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Stripe Publishable Key','obti'); ?></th>
                 <td><input type="text" size="60" name="obti_settings[stripe_publishable_key]" value="<?php echo esc_attr($o['stripe_publishable_key']); ?>"></td></tr>
-              <tr><th><?php esc_html_e('Stripe Webhook Secret','obti'); ?></th>
+            <tr><th><?php esc_html_e('Stripe Webhook Secret','obti'); ?></th>
                 <td><input type="text" size="60" name="obti_settings[stripe_webhook_secret]" value="<?php echo esc_attr($o['stripe_webhook_secret']); ?>"></td></tr>
+              <tr><th><?php esc_html_e('Google Reviews link','obti'); ?></th>
+                <td><input type="url" size="60" name="obti_settings[google_reviews_url]" value="<?php echo esc_attr($o['google_reviews_url']); ?>"></td></tr>
               <tr><th><?php esc_html_e('Stripe Connect — Enabled','obti'); ?></th>
                 <td><input type="checkbox" name="obti_settings[connect_enabled]" value="1" <?php checked(!empty($o['connect_enabled'])); ?>></td></tr>
               <tr><th><?php esc_html_e('Connect Platform Secret Key (Totaliweb)','obti'); ?></th>


### PR DESCRIPTION
## Summary
- Schedule `obti_booking_complete` three hours after start and mark booking as completed with follow-up email.
- Add Google Reviews link setting for customizable review URL.
- Introduce completion email template encouraging reviews.

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-cron.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-completed.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a8b70c4083339a69b08c01e76736