### PR TITLE
Add shared header/footer and dynamic booking emails

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-cancelled.php
+++ b/wp-content/plugins/obti-booking/emails/customer-cancelled.php
@@ -1,14 +1,22 @@
 <?php
-$booking_id = $booking_id ?? 0;
-$name  = get_post_meta($booking_id,'_obti_name', true);
-$date  = get_post_meta($booking_id,'_obti_date', true);
-$time  = get_post_meta($booking_id,'_obti_time', true);
+$booking_id   = $booking_id ?? 0;
+$name         = get_post_meta( $booking_id, '_obti_name', true );
+$date         = get_post_meta( $booking_id, '_obti_date', true );
+$time         = get_post_meta( $booking_id, '_obti_time', true );
+$checkout_url = $checkout_url ?? '#';
+$email        = get_post_meta( $booking_id, '_obti_email', true );
+$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
+$account_page_id = obti_get_page_id( 'My Bookings' );
+$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
 ?>
-<!doctype html>
-<html><body style="font-family:Inter,Arial,sans-serif;background:#ffffff;padding:16px;">
-  <h2>Booking Cancelled</h2>
-  <p>Hi <?php echo esc_html($name); ?>, your booking #<?php echo intval($booking_id); ?> for <?php echo esc_html($date.' '.$time); ?> has been cancelled. A refund has been initiated.</p>
-  <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
-    Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
-  </p>
-</body></html>
+<?php include __DIR__ . '/partials/header.php'; ?>
+<h2 style="margin:0 0 8px 0;">
+  <?php echo esc_html__( 'Booking Cancelled', 'obti' ); ?>
+</h2>
+<p style="margin:0 0 16px 0;">
+  <?php echo sprintf( esc_html__( 'Hi %1$s, your booking #%2$s for %3$s at %4$s has been cancelled. A refund has been initiated.', 'obti' ), esc_html( $name ), intval( $booking_id ), esc_html( $date ), esc_html( $time ) ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
+</p>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-confirmed.php
@@ -1,38 +1,47 @@
 <?php
-$booking_id = $booking_id ?? 0;
-$name  = get_post_meta($booking_id,'_obti_name', true);
-$email = get_post_meta($booking_id,'_obti_email', true);
-$date  = get_post_meta($booking_id,'_obti_date', true);
-$time  = get_post_meta($booking_id,'_obti_time', true);
-$qty   = (int) get_post_meta($booking_id,'_obti_qty', true);
-$total = get_post_meta($booking_id,'_obti_total', true);
-$token = get_post_meta($booking_id,'_obti_manage_token', true);
-$address = OBTI_Settings::get('address_label','Forio');
-$account_page_id = obti_get_page_id('My Bookings');
-$link = $account_page_id ? add_query_arg(['token'=>$token,'email'=>$email], get_permalink($account_page_id)) : home_url('/');
+$booking_id   = $booking_id ?? 0;
+$name         = get_post_meta( $booking_id, '_obti_name', true );
+$email        = get_post_meta( $booking_id, '_obti_email', true );
+$date         = get_post_meta( $booking_id, '_obti_date', true );
+$time         = get_post_meta( $booking_id, '_obti_time', true );
+$qty          = (int) get_post_meta( $booking_id, '_obti_qty', true );
+$total        = get_post_meta( $booking_id, '_obti_total', true );
+$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
+$address      = OBTI_Settings::get( 'address_label', 'Forio' );
+$account_page_id = obti_get_page_id( 'My Bookings' );
+$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$checkout_url = $checkout_url ?? '#';
 ?>
-<!doctype html>
-<html>
-  <body style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px;">
-    <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb">
-      <div style="background:#16a34a;color:#fff;padding:20px 24px;">
-        <h1 style="margin:0;font-size:22px;">OpenBusTourIschia.com</h1>
-      </div>
-      <div style="padding:24px;">
-        <h2 style="margin:0 0 8px 0;">Booking Confirmed</h2>
-        <p style="margin:0 0 16px 0;">Hi <?php echo esc_html($name); ?>, thank you for your booking.</p>
-        <table style="width:100%;border-collapse:collapse">
-          <tr><td style="padding:6px 0;color:#6b7280">Date/Time</td><td style="text-align:right;font-weight:600"><?php echo esc_html($date.' '.$time); ?></td></tr>
-          <tr><td style="padding:6px 0;color:#6b7280">Tickets</td><td style="text-align:right;font-weight:600"><?php echo esc_html($qty); ?></td></tr>
-          <tr><td style="padding:6px 0;color:#6b7280">Total</td><td style="text-align:right;font-weight:600">€<?php echo esc_html($total); ?></td></tr>
-          <tr><td style="padding:6px 0;color:#6b7280">Departure/Return</td><td style="text-align:right;font-weight:600"><?php echo esc_html($address); ?></td></tr>
-        </table>
-        <p style="margin-top:12px;color:#111827">Manage or cancel (up to 72h before): <a href="<?php echo esc_url($link); ?>" style="color:#16a34a">My Bookings</a></p>
-        <p style="margin-top:12px;color:#374151;font-size:14px">In case of bad weather or cancellation we offer a full refund or the possibility to reschedule.</p>
-      </div>
-      <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
-        Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
-      </p>
-    </div>
-  </body>
-</html>
+<?php include __DIR__ . '/partials/header.php'; ?>
+<h2 style="margin:0 0 8px 0;"><?php echo esc_html__( 'Booking Confirmed', 'obti' ); ?></h2>
+<p style="margin:0 0 16px 0;">
+  <?php echo sprintf( esc_html__( 'Hi %s, thank you for your booking.', 'obti' ), esc_html( $name ) ); ?>
+</p>
+<table style="width:100%;border-collapse:collapse">
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Date/Time', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600"><?php echo esc_html( $date . ' ' . $time ); ?></td>
+  </tr>
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Tickets', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600"><?php echo esc_html( $qty ); ?></td>
+  </tr>
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Total', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600">€<?php echo esc_html( $total ); ?></td>
+  </tr>
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Departure/Return', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600"><?php echo esc_html( $address ); ?></td>
+  </tr>
+</table>
+<p style="margin-top:12px;color:#111827;">
+  <?php printf( esc_html__( 'Pay outstanding balance: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
+</p>
+<p style="margin-top:12px;color:#111827;">
+  <?php printf( esc_html__( 'Manage or cancel (up to 72h before): %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'My Bookings', 'obti' ) . '</a>' ); ?>
+</p>
+<p style="margin-top:12px;color:#374151;font-size:14px">
+  <?php echo esc_html__( 'In case of bad weather or cancellation we offer a full refund or the possibility to reschedule.', 'obti' ); ?>
+</p>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-in-progress.php
+++ b/wp-content/plugins/obti-booking/emails/customer-in-progress.php
@@ -8,19 +8,18 @@ $email        = get_post_meta( $booking_id, '_obti_email', true );
 $token        = get_post_meta( $booking_id, '_obti_manage_token', true );
 $account_page_id = obti_get_page_id( 'My Bookings' );
 $dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
-$reviews_url  = $reviews_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
-  <?php echo esc_html__( 'Thank you for travelling with us', 'obti' ); ?>
+  <?php echo esc_html__( 'Booking In Progress', 'obti' ); ?>
 </h2>
 <p style="margin:0 0 16px 0;">
-  <?php echo sprintf( esc_html__( '%1$s, we hope you enjoyed your tour on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
+  <?php echo sprintf( esc_html__( 'Hi %1$s, your booking for %2$s at %3$s is currently in progress.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
-  <?php printf( esc_html__( 'Leave a review: %s', 'obti' ), '<a href="' . esc_url( $reviews_url ) . '" style="color:#16a34a;">' . esc_html__( 'Review on Google', 'obti' ) . '</a>' ); ?>
+  <?php printf( esc_html__( 'If you need to complete payment, use the following link: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
-  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
+  <?php printf( esc_html__( 'Manage your booking here: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
 </p>
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-onboard.php
+++ b/wp-content/plugins/obti-booking/emails/customer-onboard.php
@@ -1,23 +1,29 @@
 <?php
-$booking_id = $booking_id ?? 0;
-$name  = get_post_meta($booking_id,'_obti_name', true);
-$ebook_url = $ebook_url ?? '#';
+$booking_id   = $booking_id ?? 0;
+$name         = get_post_meta( $booking_id, '_obti_name', true );
+$date         = get_post_meta( $booking_id, '_obti_date', true );
+$time         = get_post_meta( $booking_id, '_obti_time', true );
+$checkout_url = $checkout_url ?? '#';
+$email        = get_post_meta( $booking_id, '_obti_email', true );
+$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
+$account_page_id = obti_get_page_id( 'My Bookings' );
+$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$ebook_url    = $ebook_url ?? '#';
 ?>
-<!doctype html>
-<html>
-  <body style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px;">
-    <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb">
-      <div style="background:#16a34a;color:#fff;padding:20px 24px;">
-        <h1 style="margin:0;font-size:22px;">OpenBusTourIschia.com</h1>
-      </div>
-      <div style="padding:24px;">
-        <h2 style="margin:0 0 8px 0;"><?php esc_html_e('Benvenuto a bordo','obti'); ?></h2>
-        <p style="margin:0 0 16px 0;"><?php echo esc_html($name); ?>, <?php esc_html_e('il tour sta per partire.','obti'); ?></p>
-        <p style="margin:0 0 16px 0;"><a href="<?php echo esc_url($ebook_url); ?>" style="color:#16a34a;"><?php esc_html_e('Scarica il nostro eBook','obti'); ?></a></p>
-      </div>
-      <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
-        Powered by <a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>
-      </p>
-    </div>
-  </body>
-</html>
+<?php include __DIR__ . '/partials/header.php'; ?>
+<h2 style="margin:0 0 8px 0;"><?php echo esc_html__( 'Welcome aboard', 'obti' ); ?></h2>
+<p style="margin:0 0 16px 0;">
+  <?php echo sprintf( esc_html__( '%1$s, your tour on %2$s at %3$s is coming up.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <a href="<?php echo esc_url( $ebook_url ); ?>" style="color:#16a34a;">
+    <?php echo esc_html__( 'Download our eBook', 'obti' ); ?>
+  </a>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php printf( esc_html__( 'Complete your payment here: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
+</p>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-pending.php
+++ b/wp-content/plugins/obti-booking/emails/customer-pending.php
@@ -1,10 +1,28 @@
 <?php
-$booking_id = $booking_id ?? 0;
-$name  = get_post_meta($booking_id,'_obti_name', true);
-$date  = get_post_meta($booking_id,'_obti_date', true);
-$time  = get_post_meta($booking_id,'_obti_time', true);
+$booking_id   = $booking_id ?? 0;
+$name         = get_post_meta( $booking_id, '_obti_name', true );
+$date         = get_post_meta( $booking_id, '_obti_date', true );
+$time         = get_post_meta( $booking_id, '_obti_time', true );
+$checkout_url = $checkout_url ?? '#';
+$email        = get_post_meta( $booking_id, '_obti_email', true );
+$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
+$account_page_id = obti_get_page_id( 'My Bookings' );
+$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
 ?>
-<p style="margin:0 0 16px 0;">Hi <?php echo esc_html($name); ?>,</p>
-<p style="margin:0 0 16px 0;">Your booking #<?php echo intval($booking_id); ?> for <?php echo esc_html($date.' '.$time); ?> is reserved for 30 minutes. Please complete payment to confirm your seat.</p>
-<p style="margin:0 0 16px 0;"><a href="<?php echo esc_url($checkout_url); ?>">Pay now</a></p>
-<p style="margin:0 0 16px 0;">If payment isn't completed in time, the reservation will be cancelled automatically.</p>
+<?php include __DIR__ . '/partials/header.php'; ?>
+<p style="margin:0 0 16px 0;">
+  <?php echo sprintf( esc_html__( 'Hi %s,', 'obti' ), esc_html( $name ) ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php echo sprintf( esc_html__( 'Your booking #%1$s for %2$s %3$s is reserved for 30 minutes. Please complete payment to confirm your seat.', 'obti' ), intval( $booking_id ), esc_html( $date ), esc_html( $time ) ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php printf( esc_html__( 'Complete payment here: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
+</p>
+<p style="margin:0 0 16px 0;">
+  <?php echo esc_html__( 'If payment isn\'t completed in time, the reservation will be cancelled automatically.', 'obti' ); ?>
+</p>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-reminder.php
+++ b/wp-content/plugins/obti-booking/emails/customer-reminder.php
@@ -8,17 +8,16 @@ $email        = get_post_meta( $booking_id, '_obti_email', true );
 $token        = get_post_meta( $booking_id, '_obti_manage_token', true );
 $account_page_id = obti_get_page_id( 'My Bookings' );
 $dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
-$reviews_url  = $reviews_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
-  <?php echo esc_html__( 'Thank you for travelling with us', 'obti' ); ?>
+  <?php echo esc_html__( 'Reminder: Your tour is in 24 hours', 'obti' ); ?>
 </h2>
 <p style="margin:0 0 16px 0;">
-  <?php echo sprintf( esc_html__( '%1$s, we hope you enjoyed your tour on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
+  <?php echo sprintf( esc_html__( 'Hi %1$s, this is a reminder for your booking on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
-  <?php printf( esc_html__( 'Leave a review: %s', 'obti' ), '<a href="' . esc_url( $reviews_url ) . '" style="color:#16a34a;">' . esc_html__( 'Review on Google', 'obti' ) . '</a>' ); ?>
+  <?php printf( esc_html__( 'Complete payment now if you haven\'t already: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
   <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>

--- a/wp-content/plugins/obti-booking/emails/partials/footer.php
+++ b/wp-content/plugins/obti-booking/emails/partials/footer.php
@@ -1,0 +1,16 @@
+      </div>
+      <p style="font-size:12px;color:#aaa;text-align:center;margin-top:20px">
+        <?php
+        echo wp_kses(
+            sprintf(
+                __( 'Powered by %1$s – %2$s', 'obti' ),
+                '<a href="https://www.totaliweb.com" style="color:#16a34a">Totaliweb</a>',
+                '<a href="https://www.totaliweb.com" style="color:#16a34a">https://www.totaliweb.com</a>'
+            ),
+            [ 'a' => [ 'href' => [], 'style' => [] ] ]
+        );
+        ?>
+      </p>
+    </div>
+  </body>
+</html>

--- a/wp-content/plugins/obti-booking/emails/partials/header.php
+++ b/wp-content/plugins/obti-booking/emails/partials/header.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Email Header
+ */
+?>
+<!doctype html>
+<html>
+  <body style="font-family:Inter,Arial,sans-serif;background:#f8fafc;padding:24px;">
+    <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb">
+      <div style="background:#16a34a;color:#fff;padding:20px 24px;">
+        <h1 style="margin:0;font-size:22px;"><?php echo esc_html( get_bloginfo('name') ); ?></h1>
+      </div>
+      <div style="padding:24px;">


### PR DESCRIPTION
## Summary
- add header/footer partials with theme styling and Totaliweb credit
- update booking emails with placeholders and translations
- add new in-progress and reminder templates

## Testing
- `find wp-content/plugins/obti-booking/emails -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a0aac80c148333bb3d3065c2c56fb7