### PR TITLE
Add booking reminder email 24h before tour

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-reminder.php
+++ b/wp-content/plugins/obti-booking/emails/customer-reminder.php
@@ -3,23 +3,31 @@ $booking_id   = $booking_id ?? 0;
 $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
-$checkout_url = $checkout_url ?? '#';
 $email        = get_post_meta( $booking_id, '_obti_email', true );
 $token        = get_post_meta( $booking_id, '_obti_manage_token', true );
+$address      = OBTI_Settings::get( 'address_label', 'Forio' );
 $account_page_id = obti_get_page_id( 'My Bookings' );
 $dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
-  <?php echo esc_html__( 'Reminder: Your tour is in 24 hours', 'obti' ); ?>
+  <?php echo esc_html__( 'Booking Reminder', 'obti' ); ?>
 </h2>
 <p style="margin:0 0 16px 0;">
-  <?php echo sprintf( esc_html__( 'Hi %1$s, this is a reminder for your booking on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
+  <?php echo sprintf( esc_html__( 'Hi %1$s, here is a reminder for your booking on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
 </p>
-<p style="margin:0 0 16px 0;">
-  <?php printf( esc_html__( 'Complete payment now if you haven\'t already: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
-</p>
-<p style="margin:0 0 16px 0;">
-  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
+<table style="width:100%;border-collapse:collapse">
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Date/Time', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600"><?php echo esc_html( $date . ' ' . $time ); ?></td>
+  </tr>
+  <tr>
+    <td style="padding:6px 0;color:#6b7280"><?php echo esc_html__( 'Meeting Point', 'obti' ); ?></td>
+    <td style="text-align:right;font-weight:600"><?php echo esc_html( $address ); ?></td>
+  </tr>
+</table>
+<p style="margin-top:12px;color:#111827;">
+  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'My Bookings', 'obti' ) . '</a>' ); ?>
 </p>
 <?php include __DIR__ . '/partials/footer.php'; ?>
+

--- a/wp-content/plugins/obti-booking/includes/class-obti-cron.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-cron.php
@@ -7,6 +7,7 @@ class OBTI_Cron {
         add_action('transition_post_status', [__CLASS__, 'schedule_booking_start'], 10, 3);
         add_action('obti_booking_start', [__CLASS__, 'handle_booking_start']);
         add_action('obti_booking_complete', [__CLASS__, 'handle_booking_complete']);
+        add_action('obti_booking_reminder', [__CLASS__, 'handle_booking_reminder']);
     }
     // Remove expired holds
     public static function cleanup(){
@@ -27,6 +28,7 @@ class OBTI_Cron {
     public static function schedule_booking_start($new_status, $old_status, $post){
         if ($post->post_type !== 'obti_booking') return;
         wp_clear_scheduled_hook('obti_booking_start', [$post->ID]);
+        wp_clear_scheduled_hook('obti_booking_reminder', [$post->ID]);
         if ($new_status !== 'obti-confirmed') return;
         $date = get_post_meta($post->ID,'_obti_date', true);
         $time = get_post_meta($post->ID,'_obti_time', true);
@@ -34,6 +36,9 @@ class OBTI_Cron {
         $ts = strtotime($date.' '.$time.' '.obti_wp_timezone_string());
         if ($ts){
             wp_schedule_single_event($ts, 'obti_booking_start', [$post->ID]);
+            if ($ts - DAY_IN_SECONDS > time()){
+                wp_schedule_single_event($ts - DAY_IN_SECONDS, 'obti_booking_reminder', [$post->ID]);
+            }
         }
     }
 
@@ -49,6 +54,21 @@ class OBTI_Cron {
             wp_clear_scheduled_hook('obti_booking_complete', [$booking_id]);
             wp_schedule_single_event($ts + 3 * HOUR_IN_SECONDS, 'obti_booking_complete', [$booking_id]);
         }
+    }
+
+    public static function handle_booking_reminder($booking_id){
+        if (get_post_status($booking_id) !== 'obti-confirmed') return;
+        self::email_customer_reminder($booking_id);
+    }
+
+    private static function email_customer_reminder($booking_id){
+        $to = get_post_meta($booking_id,'_obti_email', true);
+        if (!$to) return;
+        $subject = __('Promemoria prenotazione','obti');
+        $html = OBTI_Webhooks::render_email_template('customer-reminder.php', $booking_id);
+        add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });
+        wp_mail($to, $subject, $html);
+        remove_filter('wp_mail_content_type', '__return_false');
     }
 
     private static function email_customer_onboard($booking_id){


### PR DESCRIPTION
## Summary
- schedule `obti_booking_reminder` 24 hours before tour start when booking confirmed
- send reminder email with booking summary and meeting point

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-cron.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-reminder.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae1a4a788333a5f97d4bfa763244