### PR TITLE
Add booking cost breakdown and net column

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-admin.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-admin.php
@@ -25,26 +25,44 @@ class OBTI_Admin {
         add_meta_box('obti_booking_meta', __('Booking Details','obti'), [__CLASS__,'render_meta'], 'obti_booking', 'normal', 'high');
     }
     public static function render_meta($post){
-        $fields = [
+        $details = [
             'date' => get_post_meta($post->ID,'_obti_date', true),
             'time' => get_post_meta($post->ID,'_obti_time', true),
             'qty'  => get_post_meta($post->ID,'_obti_qty', true),
             'unit' => get_post_meta($post->ID,'_obti_unit_price', true),
-            'subtotal' => get_post_meta($post->ID,'_obti_subtotal', true),
-            'service_fee' => get_post_meta($post->ID,'_obti_service_fee', true),
-            'agency_fee' => get_post_meta($post->ID,'_obti_agency_fee', true),
-            'total'=> get_post_meta($post->ID,'_obti_total', true),
-            'fee_transferred' => get_post_meta($post->ID,'_obti_fee_transferred', true),
             'email'=> get_post_meta($post->ID,'_obti_email', true),
             'name' => get_post_meta($post->ID,'_obti_name', true),
             'session' => get_post_meta($post->ID,'_obti_stripe_session_id', true),
             'payment_intent' => get_post_meta($post->ID,'_obti_payment_intent', true),
+            'fee_transferred' => get_post_meta($post->ID,'_obti_fee_transferred', true),
         ];
+
         echo '<table class="form-table">';
-        foreach($fields as $k=>$v){
+        foreach($details as $k=>$v){
             echo '<tr><th>'.esc_html($k).'</th><td><input type="text" readonly value="'.esc_attr($v).'" style="width:100%"></td></tr>';
         }
         echo '</table>';
+
+        $subtotal    = get_post_meta($post->ID,'_obti_subtotal', true);
+        $service_fee = get_post_meta($post->ID,'_obti_service_fee', true);
+        $agency_fee  = get_post_meta($post->ID,'_obti_agency_fee', true);
+        $total       = get_post_meta($post->ID,'_obti_total', true);
+        $net         = number_format((float)$total - (float)$service_fee - (float)$agency_fee, 2, '.', '');
+
+        echo '<h2>'.esc_html__('Cost Breakdown','obti').'</h2>';
+        echo '<table class="form-table">';
+        $costs = [
+            __('Subtotal','obti')     => $subtotal,
+            __('Service fee','obti')  => $service_fee,
+            __('Agency fee','obti')   => $agency_fee,
+            __('Total','obti')        => $total,
+            __('Net','obti')          => $net,
+        ];
+        foreach($costs as $label=>$v){
+            echo '<tr><th>'.esc_html($label).'</th><td><input type="text" readonly value="'.esc_attr($v).'" style="width:100%"></td></tr>';
+        }
+        echo '</table>';
+
         wp_nonce_field('obti_booking_meta','obti_booking_meta_nonce');
     }
     public static function save_meta($post_id, $post){

--- a/wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php
@@ -39,12 +39,13 @@ class OBTI_Booking_CPT {
         }
         // Columns
         add_filter('manage_obti_booking_posts_columns', function($cols){
-            $cols['date_time'] = __('Date/Time','obti');
-            $cols['qty'] = __('Qty','obti');
-            $cols['customer'] = __('Customer','obti');
-            $cols['service_fee'] = __('Service fee','obti');
+            $cols['date_time']  = __('Date/Time','obti');
+            $cols['qty']        = __('Qty','obti');
+            $cols['customer']   = __('Customer','obti');
+            $cols['total']      = __('Total','obti');
+            $cols['service_fee']= __('Service fee','obti');
             $cols['agency_fee'] = __('Agency fee','obti');
-            $cols['total'] = __('Total','obti');
+            $cols['net']        = __('Net','obti');
             return $cols;
         });
         add_action('manage_obti_booking_posts_custom_column', function($col, $post_id){
@@ -54,12 +55,18 @@ class OBTI_Booking_CPT {
                 echo intval(get_post_meta($post_id,'_obti_qty', true));
             } elseif ($col === 'customer'){
                 echo esc_html(get_post_meta($post_id,'_obti_name', true).' <'.get_post_meta($post_id,'_obti_email', true).'>');
+            } elseif ($col === 'total'){
+                echo '€'.esc_html(get_post_meta($post_id,'_obti_total', true));
             } elseif ($col === 'service_fee'){
                 echo '€'.esc_html(get_post_meta($post_id,'_obti_service_fee', true));
             } elseif ($col === 'agency_fee'){
                 echo '€'.esc_html(get_post_meta($post_id,'_obti_agency_fee', true));
-            } elseif ($col === 'total'){
-                echo '€'.esc_html(get_post_meta($post_id,'_obti_total', true));
+            } elseif ($col === 'net'){
+                $total       = floatval(get_post_meta($post_id,'_obti_total', true));
+                $service_fee = floatval(get_post_meta($post_id,'_obti_service_fee', true));
+                $agency_fee  = floatval(get_post_meta($post_id,'_obti_agency_fee', true));
+                $net = $total - $service_fee - $agency_fee;
+                echo '€'.esc_html(number_format($net,2,'.',''));
             }
         }, 10, 2);
     }


### PR DESCRIPTION
## Summary
- show detailed cost breakdown with net calculation on booking edit screen
- display Total, Service fee, Agency fee, and Net columns in booking list
- ensure settings include service fee, agency fee percentages and Google Reviews link

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-admin.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-booking-cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0afed217883339ab936789bfcead4