### PR TITLE
Add My Account dashboard and customer admin restrictions

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-cancelled.php
+++ b/wp-content/plugins/obti-booking/emails/customer-cancelled.php
@@ -3,11 +3,8 @@ $booking_id   = $booking_id ?? 0;
 $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
-$checkout_url = $checkout_url ?? '#';
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">

--- a/wp-content/plugins/obti-booking/emails/customer-completed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-completed.php
@@ -3,11 +3,8 @@ $booking_id   = $booking_id ?? 0;
 $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
-$checkout_url = $checkout_url ?? '#';
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 $reviews_url  = $reviews_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-confirmed.php
@@ -1,15 +1,13 @@
 <?php
 $booking_id   = $booking_id ?? 0;
 $name         = get_post_meta( $booking_id, '_obti_name', true );
-$email        = get_post_meta( $booking_id, '_obti_email', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
 $qty          = (int) get_post_meta( $booking_id, '_obti_qty', true );
 $total        = get_post_meta( $booking_id, '_obti_total', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
 $address      = OBTI_Settings::get( 'address_label', 'Forio' );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 $checkout_url = $checkout_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
@@ -39,7 +37,7 @@ $checkout_url = $checkout_url ?? '#';
   <?php printf( esc_html__( 'Pay outstanding balance: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>
 </p>
 <p style="margin-top:12px;color:#111827;">
-  <?php printf( esc_html__( 'Manage or cancel (up to 72h before): %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'My Bookings', 'obti' ) . '</a>' ); ?>
+  <?php printf( esc_html__( 'Manage or cancel (up to 72h before): %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
 </p>
 <p style="margin-top:12px;color:#374151;font-size:14px">
   <?php echo esc_html__( 'In case of bad weather or cancellation we offer a full refund or the possibility to reschedule.', 'obti' ); ?>

--- a/wp-content/plugins/obti-booking/emails/customer-in-progress.php
+++ b/wp-content/plugins/obti-booking/emails/customer-in-progress.php
@@ -4,10 +4,8 @@ $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
 $checkout_url = $checkout_url ?? '#';
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">

--- a/wp-content/plugins/obti-booking/emails/customer-onboard.php
+++ b/wp-content/plugins/obti-booking/emails/customer-onboard.php
@@ -4,10 +4,8 @@ $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
 $checkout_url = $checkout_url ?? '#';
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 $ebook_url    = $ebook_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>

--- a/wp-content/plugins/obti-booking/emails/customer-pending.php
+++ b/wp-content/plugins/obti-booking/emails/customer-pending.php
@@ -4,10 +4,8 @@ $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
 $checkout_url = $checkout_url ?? '#';
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <p style="margin:0 0 16px 0;">

--- a/wp-content/plugins/obti-booking/emails/customer-reminder.php
+++ b/wp-content/plugins/obti-booking/emails/customer-reminder.php
@@ -3,11 +3,9 @@ $booking_id   = $booking_id ?? 0;
 $name         = get_post_meta( $booking_id, '_obti_name', true );
 $date         = get_post_meta( $booking_id, '_obti_date', true );
 $time         = get_post_meta( $booking_id, '_obti_time', true );
-$email        = get_post_meta( $booking_id, '_obti_email', true );
-$token        = get_post_meta( $booking_id, '_obti_manage_token', true );
 $address      = OBTI_Settings::get( 'address_label', 'Forio' );
-$account_page_id = obti_get_page_id( 'My Bookings' );
-$dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' => $email], get_permalink( $account_page_id ) ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' );
+$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
@@ -27,7 +25,7 @@ $dashboard_url = $account_page_id ? add_query_arg( ['token' => $token, 'email' =
   </tr>
 </table>
 <p style="margin-top:12px;color:#111827;">
-  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'My Bookings', 'obti' ) . '</a>' ); ?>
+  <?php printf( esc_html__( 'Manage your booking: %s', 'obti' ), '<a href="' . esc_url( $dashboard_url ) . '" style="color:#16a34a;">' . esc_html__( 'Dashboard', 'obti' ) . '</a>' ); ?>
 </p>
 <?php include __DIR__ . '/partials/footer.php'; ?>
 

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -63,7 +63,8 @@ function obti_maybe_create_pages(){
     $pages = [
         'Booking Success' => '[obti_booking_success]',
         'Booking Cancelled' => '[obti_booking_cancel]',
-        'My Bookings' => '[obti_account]'
+        'My Bookings' => '[obti_account]',
+        'My Account' => '[obti_dashboard]'
     ];
     foreach($pages as $title=>$shortcode){
         $exists = obti_get_page_id($title);
@@ -172,6 +173,29 @@ add_shortcode('obti_account', function(){
     </script>
     <?php
     return ob_get_clean();
+});
+
+// Redirect obti_customer role away from wp-admin and hide admin bar
+add_action('admin_init', function(){
+    if ( wp_doing_ajax() ) {
+        return;
+    }
+    $user = wp_get_current_user();
+    if ( in_array( 'obti_customer', (array) $user->roles, true ) ) {
+        $page_id = obti_get_page_id( 'My Account' );
+        if ( $page_id ) {
+            wp_safe_redirect( get_permalink( $page_id ) );
+            exit;
+        }
+    }
+});
+
+add_filter('show_admin_bar', function( $show ){
+    $user = wp_get_current_user();
+    if ( in_array( 'obti_customer', (array) $user->roles, true ) ) {
+        return false;
+    }
+    return $show;
 });
 
 // Helper: can cancel?

--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -60,3 +60,14 @@ add_action('wp_enqueue_scripts', function(){
     wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], '2.15.0', true);
     wp_enqueue_script('turf', 'https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js', [], '6.5.0', true);
 });
+
+// Shortcode for dashboard widget
+add_shortcode('obti_dashboard', function(){
+    if ( ! class_exists('\\OBTI_EW\\Dashboard') ) {
+        require_once OBTI_EW_DIR.'widgets/class-obti-dashboard.php';
+    }
+    ob_start();
+    $widget = new \OBTI_EW\Dashboard();
+    $widget->render();
+    return ob_get_clean();
+});


### PR DESCRIPTION
## Summary
- Create "My Account" page with OBTI Dashboard widget and shortcode
- Redirect `obti_customer` users away from `/wp-admin/` and hide admin bar
- Update customer emails to link directly to the new dashboard

## Testing
- `php -l wp-content/plugins/obti-booking/obti-booking.php`
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-cancelled.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-completed.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-confirmed.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-in-progress.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-onboard.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-pending.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-reminder.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0b1eb629c8333929b9ce78696ce45