### PR TITLE
Simplify dashboard navigation and support tab URLs

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/assets/js/dashboard.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/dashboard.js
@@ -18,19 +18,10 @@
         e.preventDefault();
         var t = a.getAttribute('data-tab');
         show(t);
+        history.replaceState(null, '', '?tab=' + t);
         if(t === 'bookings'){ loadBookings(); }
       });
     });
-
-    var avatarBtn = qs('#obti-avatar-btn', wrap);
-    var avatarMenu = qs('#obti-avatar-menu', wrap);
-    if(avatarBtn && avatarMenu){
-      avatarBtn.addEventListener('click', function(e){
-        e.stopPropagation();
-        avatarMenu.classList.toggle('hidden');
-      });
-      document.addEventListener('click', function(){ avatarMenu.classList.add('hidden'); });
-    }
 
     var modal = qs('#obti-booking-modal');
     var closeModal = function(){ modal.classList.add('hidden'); };
@@ -131,6 +122,7 @@
     }
 
     loadBookings();
-    show('dashboard');
+    var initialTab = new URLSearchParams(location.search).get('tab') || 'dashboard';
+    show(initialTab);
   });
 })();

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
@@ -23,18 +23,12 @@ class Dashboard extends Widget_Base {
             <aside class="md:w-64 border-b md:border-b-0 md:border-r">
                 <nav class="flex md:flex-col">
                     <a href="#" data-tab="dashboard" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">Dashboard</a>
-                    <a href="#" data-tab="bookings" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">Le Mie Prenotazioni</a>
-                    <a href="#" data-tab="profile" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">Il Mio Profilo</a>
+                    <a href="#" data-tab="bookings" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">My Bookings</a>
+                    <a href="#" data-tab="profile" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">My Profile</a>
+                    <a href="/logout" class="px-4 py-3 text-center md:text-left md:py-4 obti-tab-link">Logout</a>
                 </nav>
             </aside>
             <div class="flex-1 p-6">
-                <header class="flex justify-end mb-6 relative">
-                    <button id="obti-avatar-btn" class="w-10 h-10 rounded-full bg-gray-200"></button>
-                    <div id="obti-avatar-menu" class="hidden absolute right-0 top-full mt-2 w-40 bg-white border rounded shadow-lg">
-                        <a href="#" data-tab="profile" class="block px-4 py-2 text-sm hover:bg-gray-100">Il Mio Profilo</a>
-                        <a href="/logout" class="block px-4 py-2 text-sm hover:bg-gray-100">Logout</a>
-                    </div>
-                </header>
                 <div id="obti-tab-dashboard" class="obti-tab">
                     <h2 class="text-2xl font-bold mb-4">Dashboard</h2>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
@@ -52,11 +46,11 @@ class Dashboard extends Widget_Base {
                     </div>
                 </div>
                 <div id="obti-tab-bookings" class="obti-tab hidden">
-                    <h2 class="text-2xl font-bold mb-4"><?php esc_html_e('Le Mie Prenotazioni','obti'); ?></h2>
+                    <h2 class="text-2xl font-bold mb-4"><?php esc_html_e('My Bookings','obti'); ?></h2>
                     <ul id="obti-bookings-list" class="space-y-4"></ul>
                 </div>
                 <div id="obti-tab-profile" class="obti-tab hidden">
-                    <h2 class="text-2xl font-bold mb-4"><?php esc_html_e('Il Mio Profilo','obti'); ?></h2>
+                    <h2 class="text-2xl font-bold mb-4"><?php esc_html_e('My Profile','obti'); ?></h2>
                     <form id="obti-profile-form" class="space-y-4">
                         <div>
                             <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Nome completo','obti'); ?></label>

--- a/wp-content/themes/obti/header.php
+++ b/wp-content/themes/obti/header.php
@@ -54,8 +54,8 @@
         </button>
         <ul id="user-dropdown-desktop" class="hidden absolute right-0 mt-2 w-48 bg-white border rounded shadow-md">
           <li><a href="<?php echo esc_url(home_url('/dashboard')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
-          <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
           <li><a href="<?php echo esc_url(home_url('/dashboard?tab=bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+          <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
           <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
         </ul>
       </div>
@@ -86,8 +86,8 @@
       </button>
       <ul id="user-dropdown-mobile" class="hidden mt-2 w-full bg-white border rounded shadow-md">
         <li><a href="<?php echo esc_url(home_url('/dashboard')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Dashboard', 'obti'); ?></a></li>
-        <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
         <li><a href="<?php echo esc_url(home_url('/dashboard?tab=bookings')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Bookings', 'obti'); ?></a></li>
+        <li><a href="<?php echo esc_url(home_url('/dashboard?tab=profile')); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Profile', 'obti'); ?></a></li>
         <li><a href="<?php echo esc_url(wp_logout_url(home_url())); ?>" class="block px-4 py-2 hover:bg-gray-100"><?php _e('Logout', 'obti'); ?></a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Remove dashboard avatar dropdown and translate sidebar links to English, including a logout option
- Parse `?tab` from the URL and update browser history when switching dashboard tabs
- Point theme header dropdown links to `/dashboard?tab=bookings` and `/dashboard?tab=profile`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd wp-content/themes/obti && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0f0d54ca483339c72d2d0801face8