### PR TITLE
Translate Italian user messages

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-cron.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-cron.php
@@ -64,7 +64,7 @@ class OBTI_Cron {
     private static function email_customer_reminder($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Promemoria prenotazione','obti');
+        $subject = __('Booking Reminder','obti');
         $html = OBTI_Webhooks::render_email_template('customer-reminder.php', $booking_id);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });
         wp_mail($to, $subject, $html);
@@ -74,7 +74,7 @@ class OBTI_Cron {
     private static function email_customer_onboard($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Benvenuto a bordo','obti');
+        $subject = __('Welcome aboard','obti');
         $ebook_url = apply_filters('obti_booking_ebook_url', '#');
         $html = OBTI_Webhooks::render_email_template('customer-onboard.php', $booking_id, ['ebook_url'=>$ebook_url]);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });
@@ -91,7 +91,7 @@ class OBTI_Cron {
     private static function email_customer_completed($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Grazie per aver viaggiato con noi','obti');
+        $subject = __('Thank you for travelling with us','obti');
         $reviews_url = OBTI_Settings::get('google_reviews_url', '#');
         $html = OBTI_Webhooks::render_email_template('customer-completed.php', $booking_id, ['reviews_url'=>$reviews_url]);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });

--- a/wp-content/plugins/obti-elementor-widgets/assets/js/dashboard.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/dashboard.js
@@ -89,20 +89,20 @@
           method: 'POST',
           headers: {'Content-Type':'application/json'},
           body: JSON.stringify({first_name:first,last_name:last,email:emailInput.value.trim()})
-        }).then(function(){ alert('Profilo aggiornato'); }).catch(function(){});
+        }).then(function(){ alert('Profile updated'); }).catch(function(){});
       });
     }
     if(passSaveBtn){
       passSaveBtn.addEventListener('click', function(){
         var p1 = newPassInput.value;
         var p2 = confirmPassInput.value;
-        if(p1 !== p2 || !p1){ alert('Le password non coincidono'); return; }
+        if(p1 !== p2 || !p1){ alert('Passwords do not match'); return; }
         fetch(api + '/password', {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
           body: JSON.stringify({password:p1})
         }).then(function(){
-          alert('Password aggiornata');
+          alert('Password updated');
           newPassInput.value='';
           confirmPassInput.value='';
         }).catch(function(){});
@@ -124,7 +124,7 @@
             var li = document.createElement('li');
             li.className = 'p-4 border rounded flex justify-between items-center';
             li.innerHTML = '<div><div class="font-semibold">'+(b.title||'')+'</div><div class="text-sm text-gray-600">'+(b.date||'')+'</div></div>'+
-              '<div class="flex items-center space-x-2"><span class="px-2 py-1 rounded text-xs font-semibold '+si.cls+'">'+si.text+'</span><button class="obti-detail text-theme-primary underline" data-id="'+b.id+'">Dettagli</button></div>';
+              '<div class="flex items-center space-x-2"><span class="px-2 py-1 rounded text-xs font-semibold '+si.cls+'">'+si.text+'</span><button class="obti-detail text-theme-primary underline" data-id="'+b.id+'">Details</button></div>';
             cont.appendChild(li);
             var ts = b.date ? new Date(b.date+'T'+(b.time||'00:00')).getTime() : null;
             if(ts && (!upTs || ts < upTs) && si.text === 'Confirmed'){

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
@@ -33,15 +33,15 @@ class Dashboard extends Widget_Base {
                     <h2 class="text-2xl font-bold mb-4">Dashboard</h2>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
                         <div class="p-4 bg-blue-100 rounded text-center">
-                            <div class="text-sm text-gray-600"><?php esc_html_e('Biglietti attivi','obti'); ?></div>
+                            <div class="text-sm text-gray-600"><?php esc_html_e('Active Tickets','obti'); ?></div>
                             <div id="obti-active-count" class="text-2xl font-bold">0</div>
                         </div>
                         <div class="p-4 bg-green-100 rounded text-center">
-                            <div class="text-sm text-gray-600"><?php esc_html_e('Tour completati','obti'); ?></div>
+                            <div class="text-sm text-gray-600"><?php esc_html_e('Completed Tours','obti'); ?></div>
                             <div id="obti-completed-count" class="text-2xl font-bold">0</div>
                         </div>
                         <div class="p-4 bg-gray-100 rounded flex items-center justify-center">
-                            <a href="#" id="obti-book-btn" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Prenota','obti'); ?></a>
+                            <a href="#" id="obti-book-btn" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Book Now','obti'); ?></a>
                         </div>
                     </div>
                     <div id="obti-upcoming-card" class="hidden mb-6">
@@ -62,25 +62,25 @@ class Dashboard extends Widget_Base {
                     <h2 class="text-2xl font-bold mb-4"><?php esc_html_e('My Profile','obti'); ?></h2>
                     <form id="obti-profile-form" class="space-y-4">
                         <div>
-                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Nome completo','obti'); ?></label>
+                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Full Name','obti'); ?></label>
                             <input id="obti-profile-name" type="text" class="mt-1 w-full border rounded px-3 py-2" />
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Email','obti'); ?></label>
                             <input id="obti-profile-email" type="email" class="mt-1 w-full border rounded px-3 py-2" />
                         </div>
-                        <button type="button" id="obti-profile-save" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Aggiorna','obti'); ?></button>
+                        <button type="button" id="obti-profile-save" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Update','obti'); ?></button>
                     </form>
                     <form id="obti-password-form" class="space-y-4 mt-8 border-t pt-4">
                         <div>
-                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Nuova Password','obti'); ?></label>
+                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('New Password','obti'); ?></label>
                             <input id="obti-new-password" type="password" class="mt-1 w-full border rounded px-3 py-2" />
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Conferma Password','obti'); ?></label>
+                            <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Confirm Password','obti'); ?></label>
                             <input id="obti-confirm-password" type="password" class="mt-1 w-full border rounded px-3 py-2" />
                         </div>
-                        <button type="button" id="obti-password-save" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Cambia Password','obti'); ?></button>
+                        <button type="button" id="obti-password-save" class="bg-theme-primary text-white px-4 py-2 rounded"><?php esc_html_e('Change Password','obti'); ?></button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace Italian labels and actions in the dashboard widget with English equivalents and ensure translations use the `obti` domain.
- localize dashboard JavaScript alerts and buttons to English.
- translate cron email subjects to English for reminders, onboard notices, and completion thanks.

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-cron.php`
- `node --check wp-content/plugins/obti-elementor-widgets/assets/js/dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0f3e1e0448333aee04f5eb2d2af51