### PR TITLE
Split booking name fields and prefill Stripe customer

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -155,14 +155,16 @@ class OBTI_REST {
         $date = sanitize_text_field($params['date'] ?? '');
         $time = sanitize_text_field($params['time'] ?? '');
         $qty  = max(1, intval($params['qty'] ?? 1));
-        $name = sanitize_text_field($params['name'] ?? '');
+        $first_name = sanitize_text_field($params['first_name'] ?? '');
+        $last_name  = sanitize_text_field($params['last_name'] ?? '');
+        $name = trim($first_name . ' ' . $last_name);
         $email = sanitize_email($params['email'] ?? '');
 
-        if (!$date || !$time || !$qty || !$name || !$email){
+        if (!$date || !$time || !$qty || !$first_name || !$last_name || !$email){
             return new WP_REST_Response(['error'=>'missing_fields'], 400);
         }
 
-        $user_id = OBTI_Checkout::ensure_customer($email, $name);
+        $user_id = OBTI_Checkout::ensure_customer($email, $first_name, $last_name);
         if (is_wp_error($user_id)) {
             return new WP_REST_Response(['error'=>'user_create_failed'], 500);
         }
@@ -215,6 +217,8 @@ class OBTI_REST {
         update_post_meta($post_id, '_obti_total', number_format($subtotal + $service_fee_total,2,'.',''));
         update_post_meta($post_id, '_obti_email', $email);
         update_post_meta($post_id, '_obti_name', $name);
+        update_post_meta($post_id, '_obti_first_name', $first_name);
+        update_post_meta($post_id, '_obti_last_name', $last_name);
         update_post_meta($post_id, '_obti_currency', $currency);
         update_post_meta($post_id, '_obti_user_id', $user_id);
         update_post_meta($post_id, '_obti_hold_expires', $hold_expires);

--- a/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
+++ b/wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js
@@ -10,7 +10,8 @@
     var date = qs("#date-picker", form);
     var time = qs('select[name="time"]', form);
     var qty  = qs('input[name="qty"]', form);
-    var name = qs('input[name="name"]', form);
+    var fname = qs('input[name="first_name"]', form);
+    var lname = qs('input[name="last_name"]', form);
     var email= qs('input[name="email"]', form);
     var sumQty = qs('#obti-sum-qty');
     var sumTotal = qs('#obti-sum-total');
@@ -20,9 +21,13 @@
 
     var userId = form.getAttribute('data-user');
     if (userId) {
-      if (name) {
-        name.value = form.getAttribute('data-name') || name.value;
-        if (name.parentNode) name.parentNode.style.display = 'none';
+      if (fname) {
+        fname.value = form.getAttribute('data-first-name') || fname.value;
+        if (fname.parentNode) fname.parentNode.style.display = 'none';
+      }
+      if (lname) {
+        lname.value = form.getAttribute('data-last-name') || lname.value;
+        if (lname.parentNode) lname.parentNode.style.display = 'none';
       }
       if (email) {
         email.value = form.getAttribute('data-email') || email.value;
@@ -87,10 +92,11 @@
         date: date.value,
         time: time.value,
         qty: parseInt(qty.value||'1',10),
-        name: name.value.trim(),
+        first_name: fname.value.trim(),
+        last_name: lname.value.trim(),
         email: email.value.trim()
       };
-      if (!payload.date || !payload.time || !payload.qty || !payload.name || !payload.email){ alert('Please fill all fields'); return; }
+      if (!payload.date || !payload.time || !payload.qty || !payload.first_name || !payload.last_name || !payload.email){ alert('Please fill all fields'); return; }
       payBtn.disabled = true;
       fetch(api + '/checkout', {
         method: 'POST',

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -24,12 +24,14 @@ class Booking extends Widget_Base {
         wp_enqueue_script('obti-booking-widget');
         $ajax = esc_url( rest_url('obti/v1') );
         $user_id = 0;
-        $user_name = '';
+        $user_first_name = '';
+        $user_last_name  = '';
         $user_email = '';
         if ( is_user_logged_in() ) {
             $u = wp_get_current_user();
             $user_id = $u->ID;
-            $user_name = $u->display_name;
+            $user_first_name = $u->first_name;
+            $user_last_name  = $u->last_name;
             $user_email = $u->user_email;
         }
         ?>
@@ -41,7 +43,7 @@ class Booking extends Widget_Base {
             </div>
             <div class="max-w-4xl mx-auto bg-white rounded-2xl shadow-2xl overflow-hidden md:flex">
               <div class="md:w-1/2 p-8 md:p-12">
-                <form id="obti-booking-form" data-api="<?php echo $ajax; ?>"<?php if ($user_id) { echo ' data-user="' . esc_attr($user_id) . '" data-name="' . esc_attr($user_name) . '" data-email="' . esc_attr($user_email) . '"'; } ?>>
+                <form id="obti-booking-form" data-api="<?php echo $ajax; ?>"<?php if ($user_id) { echo ' data-user="' . esc_attr($user_id) . '" data-first-name="' . esc_attr($user_first_name) . '" data-last-name="' . esc_attr($user_last_name) . '" data-email="' . esc_attr($user_email) . '"'; } ?>>
                   <div class="space-y-6">
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Date','obti'); ?></label>
@@ -63,8 +65,12 @@ class Booking extends Widget_Base {
                       <input type="number" name="qty" min="1" value="1" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Full Name','obti'); ?></label>
-                      <input type="text" name="name" value="<?php echo esc_attr( $user_name ); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                      <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('First Name','obti'); ?></label>
+                      <input type="text" name="first_name" value="<?php echo esc_attr( $user_first_name ); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
+                    </div>
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Last Name','obti'); ?></label>
+                      <input type="text" name="last_name" value="<?php echo esc_attr( $user_last_name ); ?>" required class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-theme-primary focus:border-theme-primary">
                     </div>
                     <div>
                       <label class="block text-sm font-medium text-gray-700"><?php esc_html_e('Email','obti'); ?></label>


### PR DESCRIPTION
## Summary
- Capture separate first and last name fields in booking widget and auto-fill for logged-in users
- Send first/last names through booking flow and store them individually via REST API
- Create or reuse Stripe Customers so checkout sessions have prefilled customer data

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-checkout.php`
- `node --check wp-content/plugins/obti-elementor-widgets/assets/js/booking-widget.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f91c28a083338667ddb61cb1f5f8