### PR TITLE
Use English booking email subjects

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-completed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-completed.php
@@ -9,7 +9,7 @@ $reviews_url  = $reviews_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
-  <?php echo esc_html__( 'Thank you for travelling with us', 'obti' ); ?>
+  <?php echo esc_html__( 'Thank you for traveling with us', 'obti' ); ?>
 </h2>
 <p style="margin:0 0 16px 0;">
   <?php echo sprintf( esc_html__( '%1$s, we hope you enjoyed your tour on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>

--- a/wp-content/plugins/obti-booking/emails/customer-onboard.php
+++ b/wp-content/plugins/obti-booking/emails/customer-onboard.php
@@ -9,7 +9,7 @@ $dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url
 $ebook_url    = $ebook_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
-<h2 style="margin:0 0 8px 0;"><?php echo esc_html__( 'Welcome aboard', 'obti' ); ?></h2>
+<h2 style="margin:0 0 8px 0;"><?php echo esc_html__( 'Welcome on board', 'obti' ); ?></h2>
 <p style="margin:0 0 16px 0;">
   <?php echo sprintf( esc_html__( '%1$s, your tour on %2$s at %3$s is coming up.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>
 </p>

--- a/wp-content/plugins/obti-booking/emails/customer-reminder.php
+++ b/wp-content/plugins/obti-booking/emails/customer-reminder.php
@@ -9,7 +9,7 @@ $dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>
 <h2 style="margin:0 0 8px 0;">
-  <?php echo esc_html__( 'Booking Reminder', 'obti' ); ?>
+  <?php echo esc_html__( 'Booking reminder', 'obti' ); ?>
 </h2>
 <p style="margin:0 0 16px 0;">
   <?php echo sprintf( esc_html__( 'Hi %1$s, here is a reminder for your booking on %2$s at %3$s.', 'obti' ), esc_html( $name ), esc_html( $date ), esc_html( $time ) ); ?>

--- a/wp-content/plugins/obti-booking/includes/class-obti-cron.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-cron.php
@@ -64,7 +64,7 @@ class OBTI_Cron {
     private static function email_customer_reminder($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Booking Reminder','obti');
+        $subject = __('Booking reminder','obti');
         $html = OBTI_Webhooks::render_email_template('customer-reminder.php', $booking_id);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });
         wp_mail($to, $subject, $html);
@@ -74,7 +74,7 @@ class OBTI_Cron {
     private static function email_customer_onboard($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Welcome aboard','obti');
+        $subject = __('Welcome on board','obti');
         $ebook_url = apply_filters('obti_booking_ebook_url', '#');
         $html = OBTI_Webhooks::render_email_template('customer-onboard.php', $booking_id, ['ebook_url'=>$ebook_url]);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });
@@ -91,7 +91,7 @@ class OBTI_Cron {
     private static function email_customer_completed($booking_id){
         $to = get_post_meta($booking_id,'_obti_email', true);
         if (!$to) return;
-        $subject = __('Thank you for travelling with us','obti');
+        $subject = __('Thank you for traveling with us','obti');
         $reviews_url = OBTI_Settings::get('google_reviews_url', '#');
         $html = OBTI_Webhooks::render_email_template('customer-completed.php', $booking_id, ['reviews_url'=>$reviews_url]);
         add_filter('wp_mail_content_type', function(){ return 'text/html; charset=UTF-8'; });


### PR DESCRIPTION
## Summary
- Replace booking reminder, welcome, and completion email subjects with English equivalents
- Align corresponding email template headings with English subjects

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-cron.php && php -l wp-content/plugins/obti-booking/emails/customer-reminder.php && php -l wp-content/plugins/obti-booking/emails/customer-onboard.php && php -l wp-content/plugins/obti-booking/emails/customer-completed.php`


------
https://chatgpt.com/codex/tasks/task_e_68a10847441c8333a75bdc2855b31118