### PR TITLE
Standardize Elementor widget headers

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -1,7 +1,7 @@
 <?php
 namespace OBTI_EW;
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;


### PR DESCRIPTION
## Summary
- Simplify ABSPATH guards in widget files and keep a single `namespace OBTI_EW` declaration in each
- Preserve straightforward class names for Elementor widgets

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php`
- `php -l wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php`


------
https://chatgpt.com/codex/tasks/task_e_68a12a0414888333bf4ac2802d7d4e3d