### PR TITLE
Add helper for retrieving page IDs

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-confirmed.php
@@ -6,8 +6,8 @@ $time         = get_post_meta( $booking_id, '_obti_time', true );
 $qty          = (int) get_post_meta( $booking_id, '_obti_qty', true );
 $total        = get_post_meta( $booking_id, '_obti_total', true );
 $address      = OBTI_Settings::get( 'address_label', 'Forio' );
-$account_page_id = obti_get_page_id( 'My Account' );
-$dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
+$account_page_id = obti_get_page_id( 'My Account' ); // Retrieve My Account page ID
+$dashboard_url   = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
 $checkout_url = $checkout_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>

--- a/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
@@ -110,8 +110,8 @@ class OBTI_Checkout {
         $total = floatval(get_post_meta($booking_id,'_obti_total', true));
         $currency = strtolower(get_post_meta($booking_id,'_obti_currency', true) ?: 'eur');
 
-        $success_page_id = obti_get_page_id('Booking Success');
-        $cancel_page_id  = obti_get_page_id('Booking Cancelled');
+        $success_page_id = obti_get_page_id( 'Booking Success' );
+        $cancel_page_id  = obti_get_page_id( 'Booking Cancelled' );
         $success_url = $success_page_id ? get_permalink($success_page_id) : home_url('/');
         $cancel_url  = $cancel_page_id ? get_permalink($cancel_page_id) : home_url('/');
 

--- a/wp-content/plugins/obti-booking/includes/functions.php
+++ b/wp-content/plugins/obti-booking/includes/functions.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function obti_get_page_id( $title ) {
+    $q = new WP_Query([
+        'post_type'      => 'page',
+        'title'          => $title,
+        'posts_per_page' => 1,
+        'fields'         => 'ids',
+    ]);
+
+    return $q->have_posts() ? intval( $q->posts[0] ) : 0;
+}
+

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -13,6 +13,7 @@ define('OBTI_PLUGIN_FILE', __FILE__);
 define('OBTI_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('OBTI_PLUGIN_URL', plugin_dir_url(__FILE__));
 
+require_once OBTI_PLUGIN_DIR . 'includes/functions.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-settings.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-booking-cpt.php';
 require_once OBTI_PLUGIN_DIR . 'includes/class-obti-rest.php';
@@ -36,16 +37,6 @@ function obti_maybe_upgrade(){
     }
 }
 
-function obti_get_page_id( $title ) {
-    $q = new WP_Query([
-        'post_type'      => 'page',
-        'title'          => $title,
-        'posts_per_page' => 1,
-        'fields'         => 'ids'
-    ]);
-    return $q->have_posts() ? intval($q->posts[0]) : 0;
-}
-
 // Activation: create pages + schedule cron + flush rewrite
 register_activation_hook(__FILE__, function(){
     add_role('obti_customer', 'OBTI Customer', ['read' => true]);
@@ -67,7 +58,7 @@ function obti_maybe_create_pages(){
         'My Account' => '[obti_dashboard]'
     ];
     foreach($pages as $title=>$shortcode){
-        $exists = obti_get_page_id($title);
+        $exists = obti_get_page_id( $title );
         if (!$exists) {
             $id = wp_insert_post([ 'post_title'=>$title, 'post_type'=>'page', 'post_status'=>'publish', 'post_content'=>$shortcode ]);
         }


### PR DESCRIPTION
## Summary
- centralize page lookup logic in `obti_get_page_id()` helper
- load helper during plugin bootstrap and use it where needed
- tidy up email and checkout code referencing page IDs

## Testing
- `php -l wp-content/plugins/obti-booking/includes/functions.php`
- `php -l wp-content/plugins/obti-booking/obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-checkout.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-confirmed.php`
- `php /tmp/test_page_lookup.php`

------
https://chatgpt.com/codex/tasks/task_e_68a12f993760833387fdea70efeb9bee