### PR TITLE
Add transfers admin table with agency fee column

### DIFF
--- a/wp-content/plugins/obti-booking/includes/class-obti-settings.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-settings.php
@@ -50,7 +50,14 @@ class OBTI_Admin_Settings_Page {
     public static function menu(){
         add_menu_page('OBTI Booking', 'OBTI Booking', 'manage_options', 'obti-booking', [__CLASS__, 'render'], 'dashicons-tickets', 26);
         add_submenu_page('obti-booking', __('Settings','obti'), __('Settings','obti'), 'manage_options', 'obti-booking', [__CLASS__, 'render']);
-        add_submenu_page('obti-booking', __('Transfers Totaliweb','obti'), __('Transfers Totaliweb','obti'), 'manage_options', 'obti-transfers', ['OBTI_Transfers','render']);
+        add_submenu_page(
+            'obti-booking',
+            __('Transfers Totaliweb','obti'),
+            __('Transfers Totaliweb','obti'),
+            'manage_options',
+            'obti-transfers',
+            ['OBTI_Transfers','render']
+        );
     }
     public static function register(){
         register_setting('obti_settings_group', 'obti_settings', [

--- a/wp-content/plugins/obti-booking/includes/class-obti-transfers.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-transfers.php
@@ -6,30 +6,33 @@ if (!class_exists('WP_List_Table')) {
 
 class OBTI_Transfers_Table extends WP_List_Table {
     public function get_columns(){
+        $percent = OBTI_Settings::get('agency_fee_percent', 2.5);
         return [
-            'cliente' => __('Cliente','obti'),
-            'data' => __('Data/Ora','obti'),
-            'totale' => __('Totale','obti'),
-            'fee' => __('Fee (2.5%)','obti'),
-            'transferred' => __('Stato trasferimento','obti'),
+            'customer'    => __('Customer','obti'),
+            'datetime'    => __('Date/Time','obti'),
+            'total'       => __('Total','obti'),
+            'fee'         => sprintf(__('Agency fee (%s%%)','obti'), $percent),
+            'transferred' => __('Transfer status','obti'),
         ];
     }
 
     public function prepare_items(){
         $bookings = get_posts([
-            'post_type' => 'obti_booking',
-            'post_status' => ['obti-confirmed','obti-completed'],
+            'post_type'      => 'obti_booking',
+            'post_status'    => ['obti-confirmed','obti-completed'],
             'posts_per_page' => -1,
         ]);
+        $percent = floatval(OBTI_Settings::get('agency_fee_percent', 2.5));
         $items = [];
         foreach($bookings as $p){
             $total = (float) get_post_meta($p->ID,'_obti_total', true);
+            $fee   = round($total * $percent / 100, 2);
             $items[] = [
-                'ID' => $p->ID,
-                'cliente' => get_post_meta($p->ID,'_obti_name', true).' <'.get_post_meta($p->ID,'_obti_email', true).'>',
-                'data' => get_post_meta($p->ID,'_obti_date', true).' '.get_post_meta($p->ID,'_obti_time', true),
-                'totale' => number_format($total, 2),
-                'fee' => number_format($total * 0.025, 2),
+                'ID'          => $p->ID,
+                'customer'    => get_post_meta($p->ID,'_obti_name', true).' <'.get_post_meta($p->ID,'_obti_email', true).'>',
+                'datetime'    => get_post_meta($p->ID,'_obti_date', true).' '.get_post_meta($p->ID,'_obti_time', true),
+                'total'       => number_format($total, 2),
+                'fee'         => number_format($fee, 2),
                 'transferred' => get_post_meta($p->ID,'_obti_fee_transferred', true) === 'yes' ? 'yes' : 'no',
             ];
         }
@@ -40,8 +43,8 @@ class OBTI_Transfers_Table extends WP_List_Table {
         return esc_html($item[$column_name]);
     }
 
-    public function column_totale($item){
-        return '€'.esc_html($item['totale']);
+    public function column_total($item){
+        return '€'.esc_html($item['total']);
     }
 
     public function column_fee($item){
@@ -53,7 +56,7 @@ class OBTI_Transfers_Table extends WP_List_Table {
             return esc_html__('Yes','obti');
         }
         $nonce = wp_create_nonce('obti_mark_transferred_'.$item['ID']);
-        $url = admin_url('admin-post.php?action=obti_mark_transferred&booking='.$item['ID'].'&_wpnonce='.$nonce);
+        $url   = admin_url('admin-post.php?action=obti_mark_transferred&booking='.$item['ID'].'&_wpnonce='.$nonce);
         return esc_html__('No','obti').' <a class="button" href="'.esc_url($url).'">'.esc_html__('Mark transferred','obti').'</a>';
     }
 }


### PR DESCRIPTION
## Summary
- add Transfers Totaliweb submenu under OBTI Booking
- list confirmed/completed bookings with agency fee column and transfer status
- allow marking agency fees as transferred

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-transfers.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a199a9998c8333949470cfd4333141