### PR TITLE
Add transfers endpoint and filterable booking list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,12 @@ The `obti-booking` plugin exposes authenticated endpoints under `/wp-json/obti/v
 
 ### Authentication
 
-Requests must include either:
-
-- `Authorization: Bearer <API_KEY>` header where the key is configured in the plugin settings.
-- A logged-in WordPress user via OAuth or another supported auth method.
+Requests must authenticate as a user with the `manage_options` capability. This can be done via WordPress login cookies or an application password.
 
 ### List bookings
 
 ```
-GET /wp-json/obti/v1/bookings?date=2024-01-01&status=obti-confirmed
+GET /wp-json/obti/v1/bookings?date_from=2024-01-01&date_to=2024-01-31&status=obti-confirmed
 ```
 
 Returns an array of bookings with fields `id`, `customer`, `date`, `time`, `qty`, `total`, `agency_fee` and `transfer_status`.
@@ -100,4 +97,4 @@ Returns an array of bookings with fields `id`, `customer`, `date`, `time`, `qty`
 PATCH /wp-json/obti/v1/bookings/{id}/transfer
 ```
 
-Marks the Totaliweb agency fee as transferred for the given booking. Optionally send `status=no` to reset.
+Marks the Totaliweb agency fee as transferred (`_obti_fee_transferred=yes`) for the given booking.


### PR DESCRIPTION
## Summary
- secure booking list endpoint with admin authentication and date/status filters
- add transfer marking endpoint and expose transfer status & agency fee
- document booking endpoints and auth requirements in README

## Testing
- `php -l wp-content/plugins/obti-booking/includes/class-obti-rest.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a19d4bcbe88333a642bf73ef1493cb