### PR TITLE
Simplify widget namespaces and class names

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -50,8 +50,8 @@ add_action('elementor/widgets/register', function($widgets_manager){
     require_once OBTI_EW_DIR.'widgets/class-obti-dashboard.php';
     $widgets_manager->register( new \OBTI_EW\Hero() );
     $widgets_manager->register( new \OBTI_EW\Highlights() );
-    $widgets_manager->register( new \OBTI_EW\Schedule_Map() );
-    $widgets_manager->register( new \OBTI_EW\FAQ() );
+    $widgets_manager->register( new \OBTI_EW\ScheduleMap() );
+    $widgets_manager->register( new \OBTI_EW\Faq() );
     $widgets_manager->register( new \OBTI_EW\Booking() );
     $widgets_manager->register( new \OBTI_EW\Chatbot() );
     $widgets_manager->register( new \OBTI_EW\Dashboard() );

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -1,7 +1,6 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
@@ -1,7 +1,6 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
@@ -1,7 +1,6 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
@@ -1,13 +1,12 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Repeater;
 
-class FAQ extends Widget_Base {
+class Faq extends Widget_Base {
     public function get_name(){ return __('obti-faq','obti'); }
     public function get_title(){ return __('OBTI FAQ','obti'); }
     public function get_icon(){ return 'eicon-help-o'; }

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
@@ -1,7 +1,6 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
@@ -1,7 +1,6 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -1,12 +1,11 @@
 <?php
-namespace OBTI_EW;
-
 if ( ! defined( 'ABSPATH' ) ) exit;
+namespace OBTI_EW;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
-class Schedule_Map extends Widget_Base {
+class ScheduleMap extends Widget_Base {
     public function get_name(){ return __('obti-schedule-map','obti'); }
     public function get_title(){ return __('OBTI Schedule & Map','obti'); }
     public function get_icon(){ return 'eicon-time-line'; }


### PR DESCRIPTION
## Summary
- Move ABSPATH guards before widget namespaces
- Rename Schedule_Map to ScheduleMap and FAQ to Faq
- Register widgets using updated class names

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`
- `for f in wp-content/plugins/obti-elementor-widgets/widgets/*.php; do php -l $f; done` *(fails: Namespace declaration statement has to be the very first statement)*


------
https://chatgpt.com/codex/tasks/task_e_68a1d34afa508333a35407840a081b84