### PR TITLE
Ensure Elementor is active before registering widgets

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
+++ b/wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php
@@ -33,8 +33,14 @@ add_action('admin_notices', function(){
     }
 });
 
+if ( ! did_action( 'elementor/loaded' ) ) {
+    add_action('admin_notices', function(){
+        echo '<div class="notice notice-error"><p>' . esc_html__('Elementor plugin is required for OBTI Elementor Widgets.', 'obti') . '</p></div>';
+    });
+    return;
+}
+
 add_action('elementor/widgets/register', function($widgets_manager){
-    if ( ! did_action( 'elementor/loaded' ) ) { return; }
     if ( ! class_exists('OBTI_Settings') ) {
         add_action('admin_notices', function(){
             echo '<div class="notice notice-error"><p>' . esc_html__('OBTI Booking plugin is required for OBTI Elementor Widgets.', 'obti') . '</p></div>';


### PR DESCRIPTION
## Summary
- Verify Elementor is loaded before registering OBTI Elementor widgets
- Display admin notice when Elementor is missing and abort widget registration

## Testing
- `php -l wp-content/plugins/obti-elementor-widgets/obti-elementor-widgets.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1f1a893c08333864c011dd04b3f3b