### PR TITLE
Add page ID helper and update usage to avoid warnings

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-confirmed.php
+++ b/wp-content/plugins/obti-booking/emails/customer-confirmed.php
@@ -7,7 +7,7 @@ $qty          = (int) get_post_meta( $booking_id, '_obti_qty', true );
 $total        = get_post_meta( $booking_id, '_obti_total', true );
 $address      = OBTI_Settings::get( 'address_label', 'Forio' );
 $account_page_id = obti_get_page_id( 'My Account' ); // Retrieve My Account page ID
-$dashboard_url   = $account_page_id ? get_permalink( $account_page_id ) : home_url( '/' );
+$dashboard_url   = $account_page_id > 0 ? get_permalink( $account_page_id ) : home_url( '/' );
 $checkout_url = $checkout_url ?? '#';
 ?>
 <?php include __DIR__ . '/partials/header.php'; ?>

--- a/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-checkout.php
@@ -112,8 +112,8 @@ class OBTI_Checkout {
 
         $success_page_id = obti_get_page_id( 'Booking Success' );
         $cancel_page_id  = obti_get_page_id( 'Booking Cancelled' );
-        $success_url = $success_page_id ? get_permalink($success_page_id) : home_url('/');
-        $cancel_url  = $cancel_page_id ? get_permalink($cancel_page_id) : home_url('/');
+        $success_url     = $success_page_id > 0 ? get_permalink( $success_page_id ) : home_url( '/' );
+        $cancel_url      = $cancel_page_id > 0 ? get_permalink( $cancel_page_id )  : home_url( '/' );
 
         $success_url = add_query_arg(['session_id'=>'{CHECKOUT_SESSION_ID}','booking_id'=>$booking_id], $success_url);
         $cancel_url  = add_query_arg(['booking_id'=>$booking_id], $cancel_url);

--- a/wp-content/plugins/obti-booking/includes/functions.php
+++ b/wp-content/plugins/obti-booking/includes/functions.php
@@ -1,14 +1,35 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+/**
+ * Retrieve the ID of a page by its title.
+ *
+ * Uses a lightweight query and caches results for the duration of the request
+ * to avoid repeated database lookups. Returns `0` when no page is found.
+ *
+ * @param string $title Page title to search for.
+ * @return int          Page ID or 0 when not found.
+ */
 function obti_get_page_id( $title ) {
+    static $cache = [];
+
+    $title = sanitize_text_field( $title );
+
+    if ( isset( $cache[ $title ] ) ) {
+        return $cache[ $title ];
+    }
+
     $q = new WP_Query([
         'post_type'      => 'page',
+        'post_status'    => 'publish',
         'title'          => $title,
         'posts_per_page' => 1,
         'fields'         => 'ids',
+        'no_found_rows'  => true,
     ]);
 
-    return $q->have_posts() ? intval( $q->posts[0] ) : 0;
+    $cache[ $title ] = $q->have_posts() ? (int) $q->posts[0] : 0;
+
+    return $cache[ $title ];
 }
 

--- a/wp-content/plugins/obti-booking/obti-booking.php
+++ b/wp-content/plugins/obti-booking/obti-booking.php
@@ -57,10 +57,15 @@ function obti_maybe_create_pages(){
         'My Bookings' => '[obti_account]',
         'My Account' => '[obti_dashboard]'
     ];
-    foreach($pages as $title=>$shortcode){
-        $exists = obti_get_page_id( $title );
-        if (!$exists) {
-            $id = wp_insert_post([ 'post_title'=>$title, 'post_type'=>'page', 'post_status'=>'publish', 'post_content'=>$shortcode ]);
+    foreach( $pages as $title => $shortcode ){
+        $page_id = obti_get_page_id( $title );
+        if ( ! $page_id ) {
+            $id = wp_insert_post([
+                'post_title'   => $title,
+                'post_type'    => 'page',
+                'post_status'  => 'publish',
+                'post_content' => $shortcode,
+            ]);
         }
     }
 }
@@ -174,7 +179,7 @@ add_action('admin_init', function(){
     $user = wp_get_current_user();
     if ( in_array( 'obti_customer', (array) $user->roles, true ) ) {
         $page_id = obti_get_page_id( 'My Account' );
-        if ( $page_id ) {
+        if ( $page_id > 0 ) {
             wp_safe_redirect( get_permalink( $page_id ) );
             exit;
         }


### PR DESCRIPTION
## Summary
- add cached `obti_get_page_id()` helper
- reuse page ID helper in booking setup, checkout, and emails

## Testing
- `php -l wp-content/plugins/obti-booking/includes/functions.php`
- `php -l wp-content/plugins/obti-booking/obti-booking.php`
- `php -l wp-content/plugins/obti-booking/includes/class-obti-checkout.php`
- `php -l wp-content/plugins/obti-booking/emails/customer-confirmed.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1f2d58d948333a13588a6b551d533