### PR TITLE
Adjust booking hold timing and status transitions

### DIFF
--- a/wp-content/plugins/obti-booking/emails/customer-pending.php
+++ b/wp-content/plugins/obti-booking/emails/customer-pending.php
@@ -12,7 +12,7 @@ $dashboard_url = $account_page_id ? get_permalink( $account_page_id ) : home_url
   <?php echo sprintf( esc_html__( 'Hi %s,', 'obti' ), esc_html( $name ) ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
-  <?php echo sprintf( esc_html__( 'Your booking #%1$s for %2$s %3$s is reserved for 30 minutes. Please complete payment to confirm your seat.', 'obti' ), intval( $booking_id ), esc_html( $date ), esc_html( $time ) ); ?>
+  <?php echo sprintf( esc_html__( 'Your booking #%1$s for %2$s %3$s is reserved for 20 minutes. Please complete payment to confirm your seat.', 'obti' ), intval( $booking_id ), esc_html( $date ), esc_html( $time ) ); ?>
 </p>
 <p style="margin:0 0 16px 0;">
   <?php printf( esc_html__( 'Complete payment here: %s', 'obti' ), '<a href="' . esc_url( $checkout_url ) . '" style="color:#16a34a;">' . esc_html__( 'Pay now', 'obti' ) . '</a>' ); ?>

--- a/wp-content/plugins/obti-booking/includes/class-obti-cron.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-cron.php
@@ -35,7 +35,8 @@ class OBTI_Cron {
         if (!$date || !$time) return;
         $ts = strtotime($date.' '.$time.' '.obti_wp_timezone_string());
         if ($ts){
-            wp_schedule_single_event($ts, 'obti_booking_start', [$post->ID]);
+            // Trigger 30 minutes before tour start
+            wp_schedule_single_event($ts - 30 * MINUTE_IN_SECONDS, 'obti_booking_start', [$post->ID]);
             if ($ts - DAY_IN_SECONDS > time()){
                 wp_schedule_single_event($ts - DAY_IN_SECONDS, 'obti_booking_reminder', [$post->ID]);
             }
@@ -46,13 +47,13 @@ class OBTI_Cron {
         if (get_post_status($booking_id) !== 'obti-confirmed') return;
         wp_update_post(['ID'=>$booking_id, 'post_status'=>'obti-in-progress']);
         self::email_customer_onboard($booking_id);
-        // Schedule completion 3 hours after start
+        // Schedule completion 165 minutes after start
         $date = get_post_meta($booking_id,'_obti_date', true);
         $time = get_post_meta($booking_id,'_obti_time', true);
         $ts = strtotime($date.' '.$time.' '.obti_wp_timezone_string());
         if ($ts){
             wp_clear_scheduled_hook('obti_booking_complete', [$booking_id]);
-            wp_schedule_single_event($ts + 3 * HOUR_IN_SECONDS, 'obti_booking_complete', [$booking_id]);
+            wp_schedule_single_event($ts + 165 * MINUTE_IN_SECONDS, 'obti_booking_complete', [$booking_id]);
         }
     }
 

--- a/wp-content/plugins/obti-booking/includes/class-obti-rest.php
+++ b/wp-content/plugins/obti-booking/includes/class-obti-rest.php
@@ -231,7 +231,7 @@ class OBTI_REST {
             'post_title'=>$title,
             'post_status'=>'obti-pending'
         ]);
-        $hold_minutes = 30;
+        $hold_minutes = 20;
         $hold_expires = time() + ($hold_minutes * MINUTE_IN_SECONDS);
         update_post_meta($post_id, '_obti_date', $date);
         update_post_meta($post_id, '_obti_time', $time);
@@ -251,7 +251,7 @@ class OBTI_REST {
         $token = wp_generate_password(32,false,false);
         update_post_meta($post_id, '_obti_manage_token', $token);
         update_post_meta($post_id, '_obti_fee_transferred', 'no');
-        set_transient('obti_hold_'.$post_id, ['expires'=>$hold_expires], 30 * MINUTE_IN_SECONDS);
+        set_transient('obti_hold_'.$post_id, ['expires'=>$hold_expires], 20 * MINUTE_IN_SECONDS);
 
         // Create Stripe Checkout Session
         $checkout = OBTI_Checkout::create_checkout_session($post_id);


### PR DESCRIPTION
## Summary
- Reduce booking hold to 20 minutes and update pending notice
- Auto-trigger status flow 30 minutes before tours and complete after 165 minutes

## Testing
- `php -l includes/class-obti-rest.php`
- `php -l includes/class-obti-cron.php`
- `php -l emails/customer-pending.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1fad283f8833384d1b8eceef17a22