### PR TITLE
Use namespaced header for Elementor widgets

### DIFF
--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-booking.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-chatbot.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-dashboard.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-faq.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-hero.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-highlights.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;

--- a/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
+++ b/wp-content/plugins/obti-elementor-widgets/widgets/class-obti-schedule-map.php
@@ -1,6 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
 namespace OBTI_EW;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;


### PR DESCRIPTION
## Summary
- Replace top lines in all Elementor widget classes with `namespace OBTI_EW` followed by an `ABSPATH` guard

## Testing
- `for f in wp-content/plugins/obti-elementor-widgets/widgets/class-obti-*.php; do php -l $f || exit 1; done`


------
https://chatgpt.com/codex/tasks/task_e_68a203a3df148333a304d2e9b49bb32d